### PR TITLE
Remove incorrect 'Conditional Compilation' best practice

### DIFF
--- a/docs/best-practices/build-system.md
+++ b/docs/best-practices/build-system.md
@@ -700,25 +700,3 @@ constexpr char kOllamaEndpoint[] = "http://localhost:11434";
 inline constexpr char kOllamaEndpoint[] = "http://localhost:11434";
 ```
 
----
-
-## ✅ Conditional Compilation
-
-**Ensure that GN conditional variable names exactly match their buildflag definitions.** A typo or partial name in an `if()` guard means the condition is always false and the guarded code is silently never compiled — no build error, no warning.
-
-```gn
-# Given this definition in buildflags.gni:
-#   enable_ai_chat_tab_management_tool = !is_android
-
-# ❌ WRONG - variable name doesn't match the definition
-if (enable_tab_management_tool) {
-  sources += [ "tab_management_tool.cc" ]  # never compiled!
-}
-
-# ✅ CORRECT - exact match
-if (enable_ai_chat_tab_management_tool) {
-  sources += [ "tab_management_tool.cc" ]
-}
-```
-
-When adding or modifying conditional compilation guards, always verify the variable name against its definition in the corresponding `.gni` file.


### PR DESCRIPTION
## Summary
- Removes the "Conditional Compilation" best practice from `docs/best-practices/build-system.md`

## What changed
Removed the entire "Conditional Compilation" section that claimed misspelled GN variable names in `if()` guards silently skip compilation with no build error or warning.

## Evidence
- PR https://github.com/brave/brave-core/pull/33986 — @petemill pushed back on the bot's review comment, pointing out that GN **does** error on undefined variables (the claim of silent failure is wrong)
- Slack discussion confirming the rule is too obvious (don't misspell variable names) and the build system already catches this

## Rationale
1. **Factually wrong:** GN produces a compile error when referencing an undefined variable — the stated failure mode (silent skip) does not occur
2. **Too obvious:** This is equivalent to "don't misspell variable names," which the build system already enforces via compile errors
3. The bot correctly spotted the real bug in the PR, but incorrectly elevated a one-off observation into a best practice with a false claim