### PR TITLE
Adjust best practices: anti-hallucination guardrails

### DIFF
--- a/docs/best-practices/build-system.md
+++ b/docs/best-practices/build-system.md
@@ -488,6 +488,8 @@ source_set("unit_tests") {
 
 **When an `#include` is only used inside a `#if BUILDFLAG(...)` block, the include must also be inside that guard.** An unconditional include for a conditionally-used header breaks builds when the feature is disabled.
 
+**IMPORTANT: Only apply this rule when the BUILDFLAG actually exists.** Before suggesting that code be wrapped in a `#if BUILDFLAG(...)` guard, verify the buildflag is defined in the codebase (check `buildflags.gni` files or existing usage). Never fabricate or assume a buildflag name — if no buildflag exists for a feature, do not invent one. Instead, check if the feature uses `base::FeatureList` runtime checks or has no compile-time guard at all.
+
 ```cpp
 // ❌ WRONG - unconditional include for conditionally-used header
 #include "chrome/browser/extensions/extension_web_ui.h"

--- a/docs/best-practices/coding-standards.md
+++ b/docs/best-practices/coding-standards.md
@@ -182,6 +182,11 @@ Also: `static` has no meaning for free functions in C++ (it's a C holdover). Use
 
 **Headers should use forward declarations instead of `#include` for types only used as pointers or references.** Move the full `#include` to the `.cc` file.
 
+**Exceptions — do NOT suggest forward declarations when:**
+- The type is **not directly `#include`d** but comes transitively through a base class header that must be included anyway (e.g., `content::WebUI*` comes through `webui_config.h` or `mojo_web_ui_controller.h` — there's nothing to remove)
+- The type is **not actually used** in the file — verify the type appears in the file before suggesting a forward declaration
+- The `#include` is for a **base class** the current class inherits from — these cannot be forward-declared
+
 ```cpp
 // ❌ WRONG - full include in header for pointer-only usage
 // my_class.h
@@ -192,6 +197,13 @@ Also: `static` has no meaning for free functions in C++ (it's a C holdover). Use
 namespace foo { class Bar; }
 // my_class.cc
 #include "components/foo/bar.h"
+
+// ✅ OK - no change needed, content::WebUI* comes transitively
+//    through base class headers that must be included anyway
+#include "content/public/browser/webui_config.h"       // base class
+#include "ui/webui/mojo_web_ui_controller.h"            // base class
+// These headers transitively provide content::WebUI* —
+// adding a forward declaration gains nothing.
 ```
 
 ---


### PR DESCRIPTION
## Summary
- Adding guardrails to prevent the bot from hallucinating BUILDFLAGs and making incorrect forward declaration suggestions

## What changed

**build-system.md** — Added verification requirement to the "Place Includes Inside BUILDFLAG Guards" rule: before suggesting code be wrapped in a `#if BUILDFLAG(...)` guard, verify the buildflag actually exists in the codebase. Never fabricate buildflag names.

**coding-standards.md** — Added three exceptions to the "Use Forward Declarations in Headers" rule:
1. Don't suggest forward-declaring types that come transitively through required base class headers (nothing to remove)
2. Don't suggest forward-declaring types that aren't actually used in the file
3. Don't suggest forward-declaring base classes (can't be forward-declared)

## Evidence
Developer pushback on [PR brave/brave-core#33725](https://github.com/brave/brave-core/pull/33725):
- [BUILDFLAG hallucination](https://github.com/brave/brave-core/pull/33725#discussion_r2854662653): Bot referenced `BUILDFLAG(ENABLE_BRAVE_CANDLE_EMBEDDING_GEMMA)` which doesn't exist
- [Wrong forward declaration](https://github.com/brave/brave-core/pull/33725#discussion_r2854783764): Bot suggested forward-declaring `content::BrowserContext` (not used in file) and `content::WebUI` (comes transitively through required base class headers)

## Rationale
The underlying best practices (BUILDFLAG guards, forward declarations) are correct. The problem is the bot applied them without verifying prerequisites — it invented a buildflag name and suggested forward-declaring types without checking they were actually included or used. These guardrails make the verification step explicit.