### PR TITLE
Adjust ARCH-052: exclude opaque resource types from mojom defaults rule

### DIFF
--- a/docs/best-practices/architecture.md
+++ b/docs/best-practices/architecture.md
@@ -964,16 +964,23 @@ if (old_value != visual_content_used_percentage_) {
 
 **Mojom struct fields should have explicit default values for safety.** Uninitialized mojom fields can lead to unexpected behavior when the struct is partially constructed.
 
+**Exception:** Do not flag fields whose types are opaque resources that must always be provided by the caller — e.g., `mojo_base.mojom.BigBuffer`, `handle`, `pending_remote`, `pending_receiver`, `pending_associated_remote`, `pending_associated_receiver`. Adding empty defaults for these types would mask bugs where a field is accidentally omitted. When in doubt whether a type benefits from a default, don't bother commenting.
+
 ```mojom
-// ❌ WRONG - no defaults
+// ❌ WRONG - no defaults on primitive/string fields
 struct ModelConfig {
   string name;
   bool supports_tools;
 };
 
-// ✅ CORRECT - explicit defaults
+// ✅ CORRECT - explicit defaults on primitive/string fields
 struct ModelConfig {
   string name = "";
   bool supports_tools = false;
+};
+
+// ✅ CORRECT - no default on opaque resource fields (must always be provided)
+struct ModelFiles {
+  mojo_base.mojom.BigBuffer weights;
 };
 ```


### PR DESCRIPTION
## Summary
- Adjusting ARCH-052 (Set Default Values in Mojom Struct Fields) to exclude opaque resource types

## What changed
Added an exception to ARCH-052 for types like `BigBuffer`, `handle`, `pending_remote`, `pending_receiver`, and similar opaque resource types that must always be provided by the caller. These types have no meaningful default, and adding empty defaults would mask bugs where a field is accidentally omitted.

## Evidence
- PR [brave/brave-core#33726](https://github.com/brave/brave-core/pull/33726#discussion_r2854973949): Bot flagged `mojo_base.mojom.BigBuffer weights` for lacking a default value. Developer explained that BigBuffer fields are opaque binary blobs that must always be provided — adding empty defaults would just mask bugs.

## Rationale
The existing rule is correct for primitive and string types (bool, int, string, enum), but opaque resource types are fundamentally different — they represent caller-provided data or handles with no sensible "zero value". Requiring defaults for these types creates a false sense of safety while actually making it harder to catch missing fields at the mojom layer.