### PR TITLE
Add .codex/skills symlink to share skills with Codex

### DIFF
--- a/.codex/skills
+++ b/.codex/skills
@@ -1,0 +1,1 @@
+../.claude/skills


### PR DESCRIPTION
Symlinks .codex/skills -> ../.claude/skills so the Codex CLI can discover the same skills as Claude Code from a single source of truth. SKILL.md frontmatter format is already cross-compatible between both tools.