### PR TITLE
Add browser-based verification to the bot via chrome-devtools MCP

### DIFF
--- a/.claude/skills/browser-verify/SKILL.md
+++ b/.claude/skills/browser-verify/SKILL.md
@@ -1,0 +1,143 @@
+---
+name: browser-verify
+description: "Verify a story's user-facing behavior by driving a real dev Brave via the chrome-devtools MCP. Launches a throwaway remote-debuggable Brave, executes a test plan, records a PASS/FAIL verdict in progress.txt. Triggers on: browser verify, verify in browser, test in browser, run the test plan, browser-verify."
+---
+
+# Browser Verification
+
+Functionally verify a story's user-facing behavior in a **real** browser — not just by
+running unit/automated tests. Drive the locally-built dev Brave through a concrete test plan
+using the `chrome-devtools` MCP, then record a PASS/FAIL verdict.
+
+This is the executable, single-source-of-truth version of the procedure referenced by
+`docs/workflow-pending.md` (step 6b). The autonomous loop (`run.sh`) also brings up the browser
+for stories flagged `"browserVerify": true`; this skill works both inside that loop (browser
+already running — reuse it) and standalone (a dev invokes it — start and stop the browser).
+
+**Determine the bot directory:** This SKILL.md lives in `.claude/skills/browser-verify/`. Derive
+the absolute bot directory from this file's path (referred to as `$BOT_DIR` below).
+
+**Prerequisite:** the `chrome-devtools` MCP must be registered in `~/.claude.json` pointing at
+`http://127.0.0.1:9223`. If the MCP tools are unavailable in this session, stop and report that
+the MCP is not configured/loaded (a Claude restart may be required after configuring it).
+
+---
+
+## Step 0: Confirm the story is browser-verifiable at all
+
+This skill is the **browser path** of the broader verification triage in
+`docs/workflow-pending.md` (step 6b). Before launching anything, confirm the change is actually
+observable by driving a browser:
+
+- **Browser-verifiable** — WebUI / settings (`brave://...`), page behavior, popup/extension UI,
+  rendering, network behavior. → Continue to Step 1.
+- **Not observable by driving a browser** — platform-specific behavior with no UI surface (e.g. a
+  **Windows-only registry / shell-integration** bug), native OS UI that can't be driven, pure
+  backend/build logic, or anything covered only by unit/browser tests. → **Stop here.** Do not
+  launch the browser. Record a **Verification** block with Testability `not-verifiable-here` (or
+  `automated-test-only`), the reason, and Verdict `NOT-VERIFIABLE-HERE` (or rely on the
+  acceptance-criteria tests), per `docs/progress-reporting.md`. Never drive an unrelated page just
+  to produce a screenshot.
+
+---
+
+## Step 1: Ensure a debuggable browser is running
+
+The browser lifecycle is owned by `$BOT_DIR/scripts/launch-brave-debug.sh`. Check whether one is
+already up before launching, so you don't stop a browser the autonomous loop started.
+
+```bash
+$BOT_DIR/scripts/launch-brave-debug.sh status
+```
+
+- **Reachable (exit 0):** a browser is already running (e.g. `run.sh` started it). Reuse it.
+  Set a note that you did **NOT** start it, so you do **NOT** stop it in Step 5.
+- **Not reachable (exit 1):** start one yourself:
+  ```bash
+  $BOT_DIR/scripts/launch-brave-debug.sh start
+  ```
+  Set a note that you **DID** start it, so you stop it in Step 5. If `start` fails (dev binary
+  missing, port held by a non-debuggable process), stop and report — verification cannot proceed.
+
+Confirm the discovery endpoint responds before driving it:
+
+```bash
+curl -fsS --max-time 2 http://127.0.0.1:9223/json/version | jq '.Browser'
+```
+
+---
+
+## Step 2: Define the test plan
+
+Write down, concretely, what the story changes and how to observe it. Keep it specific and
+reproducible:
+
+- **Preconditions** — required state/flags (the profile is throwaway; do not assume logins).
+- **Steps** — exact actions (URLs to visit, elements to click, text to enter).
+- **Expected** — the behavior the story specifies.
+
+Base this on the story description and acceptance criteria, not on assumptions about the code.
+
+---
+
+## Step 3: Execute it via the chrome-devtools MCP
+
+Drive the browser with the MCP tools:
+
+- `mcp__chrome-devtools__list_pages` / `mcp__chrome-devtools__new_page` — manage tabs.
+- `mcp__chrome-devtools__navigate_page` — go to a URL.
+- `mcp__chrome-devtools__take_snapshot` — **prefer this** to locate elements (a11y tree with uids).
+- `mcp__chrome-devtools__click` / `fill` / `type_text` / `press_key` — interact, using uids from
+  the latest snapshot.
+- `mcp__chrome-devtools__take_screenshot` (with a `filePath` inside `$BOT_DIR`) — capture visual
+  state to confirm the result and attach evidence.
+
+Record what you actually observe at each step.
+
+---
+
+## Step 4: Judge PASS / FAIL honestly
+
+Compare **Observed** against **Expected**:
+
+- If they match → **PASS**.
+- If they do not → **FAIL**. The story is NOT done. Do not transition it to "committed". Keep
+  working on the fix or report the failure.
+
+Do not rationalize a near-miss into a pass.
+
+---
+
+## Step 5: Record the verdict in progress.txt
+
+Append the **Verification** block to the `pending → committed` entry in
+`$BOT_DIR/data/progress.txt`, following the template in `docs/progress-reporting.md`:
+
+```
+- **Verification**:
+  - Testability: browser-verifiable — [one-line justification]
+  - Test plan: [preconditions; steps to observe the behavior]
+  - Expected: [behavior the story specifies]
+  - Observed: [what actually happened in the browser]
+  - Screenshots: [paths under $BOT_DIR, or "none"]
+  - Verdict: [PASS / FAIL]
+```
+
+Then tear down **only if you started the browser** in Step 1:
+
+```bash
+# Run ONLY if Step 1 launched the browser (status was "not reachable").
+# If you reused a browser run.sh started, do NOT stop it.
+$BOT_DIR/scripts/launch-brave-debug.sh stop
+```
+
+---
+
+## Summary
+
+0. Confirm the story is browser-verifiable; if not, record the verdict and stop without launching.
+1. Ensure a debuggable Brave is up on 9223 (reuse if present, else `start`).
+2. Define a concrete test plan from the story.
+3. Execute it via the chrome-devtools MCP, capturing observations + screenshots.
+4. Judge PASS/FAIL honestly — FAIL means the story is not done.
+5. Record the Verification block in progress.txt; `stop` the browser only if you started it.

--- a/config.example.json
+++ b/config.example.json
@@ -27,6 +27,9 @@
     "indexFile": "best_practices.md",
     "securityFile": "SECURITY.md"
   },
+  "browserVerify": {
+    "braveBinary": ""
+  },
   "schedules": {
     "syncRepo": false,
     "syncRepoPath": null

--- a/docs/progress-reporting.md
+++ b/docs/progress-reporting.md
@@ -17,6 +17,15 @@ APPEND to $BOT_DIR/data/progress.txt (never replace, always append).
 - **Test Results** (REQUIRED):
   - [List all acceptance criteria tests and their results]
   - All tests MUST pass before transitioning to "committed"
+- **Verification** (REQUIRED for every story):
+  - Testability: [browser-verifiable / automated-test-only / not-verifiable-here] — [one-line justification]
+  - Test plan: [preconditions; the concrete steps that exercise the behavior — URLs/elements for browser, or the tests/commands for automated-test-only]
+  - Expected: [the behavior the story specifies]
+  - Observed: [what actually happened — browser observations for the browser path, or test results; "N/A — not verifiable here" with the reason for not-verifiable-here]
+  - Screenshots: [paths to screenshots captured during browser verification, or "none"]
+  - Verdict: [PASS / FAIL / NOT-VERIFIABLE-HERE]
+    - PASS required before transitioning to "committed" for browser-verifiable and automated-test-only stories.
+    - NOT-VERIFIABLE-HERE is allowed only for not-verifiable-here (or browser-verifiable when the debug browser was unavailable this run); it MUST state why and that manual verification is still needed.
 - **Learnings for future iterations:**
   - Patterns discovered
   - Gotchas encountered

--- a/docs/workflow-pending.md
+++ b/docs/workflow-pending.md
@@ -176,6 +176,59 @@
 
    See [testing-requirements.md](./testing-requirements.md) for complete test execution requirements.
 
+6b. **DEFINE A TEST PLAN AND VERIFY THE FIX** (always — every story):
+
+   Passing the acceptance-criteria tests is necessary but not sufficient. You must also reason
+   explicitly about *how this fix can be observed to work* and verify it through the strongest
+   means available in this environment. Do this in three parts.
+
+   **(1) Write a concrete test plan.** From the story description and acceptance criteria (not
+   from assumptions about the code), write down:
+   - **Preconditions** — required state/flags (a verification browser profile is throwaway; do
+     not assume logins or saved state).
+   - **Steps** — the exact actions that exercise the changed behavior (URLs to visit, elements
+     to click, text to enter, or the tests/commands that cover it).
+   - **Expected** — the behavior the story specifies.
+
+   **(2) Triage testability.** Classify the story into exactly one class and record which one,
+   with a one-line justification:
+
+   - **`browser-verifiable`** — the change is observable in a running browser: WebUI / settings
+     (`brave://...`), page behavior, extension/popup UI, rendering, network behavior. → Go to the
+     browser path below.
+   - **`automated-test-only`** — not directly observable by driving the browser, but fully
+     covered by unit / browser / integration tests (most C++ logic changes and intermittent-test
+     fixes). → The acceptance-criteria tests from step 6 **are** the verification. Record which
+     specific tests exercise the changed behavior.
+   - **`not-verifiable-here`** — cannot be functionally verified in this environment: requires
+     another OS/platform (e.g. a **Windows-only registry / shell integration** bug), specific
+     hardware, a native OS UI that can't be driven, or release/build infrastructure. → Do **not**
+     fabricate a result. Record *why* it can't be verified here, rely on the acceptance-criteria
+     tests plus the self-review (step 9), and explicitly flag that manual verification on the
+     target platform is still required.
+
+   When unsure between `browser-verifiable` and `automated-test-only`, prefer the browser path if
+   any user-facing surface changed — a real-browser check catches integration gaps that unit
+   tests miss.
+
+   **Browser path (`browser-verifiable`).** Functionally verify in a **real** browser — automated
+   tests alone are not sufficient. When a story sets `"browserVerify": true`, `run.sh` launches a
+   remote-debuggable dev Brave on `http://127.0.0.1:9223` before this session starts and attaches
+   the `chrome-devtools` MCP; the iteration prompt says so explicitly. **Invoke the
+   `browser-verify` skill** — it is the canonical procedure: it can start/stop the browser itself
+   when needed, drives it via the chrome-devtools MCP, and judges PASS/FAIL. The Verdict must be
+   PASS before transitioning to "committed"; a FAIL means the story is NOT done.
+   - If you classified the story `browser-verifiable` but the debug browser is **not** available
+     this run (the prompt didn't mention it / the dev binary was missing and `run.sh` logged a
+     warning), record the test plan and a verdict of `NOT-VERIFIABLE-HERE` with the reason
+     "browser-verifiable but debug browser unavailable this run — set `browserVerify: true` or run
+     the browser-verify skill manually". Do not silently downgrade to tests-only without saying so.
+
+   **(3) Record the result.** Append the **Verification** block to the `pending → committed`
+   progress.txt entry (see [progress-reporting.md](./progress-reporting.md)) for **every** story,
+   regardless of class. The Verdict is `PASS` / `FAIL` / `NOT-VERIFIABLE-HERE`. Do not rationalize
+   a near-miss or an unverifiable change into a PASS.
+
 7. **CHROMIUM TEST DETECTION** (for filter file modifications only):
 
    If your fix involves adding a test to a filter file (e.g., `test/filters/browser_tests.filter`), determine if it's a Chromium test:
@@ -410,12 +463,11 @@ Only update CLAUDE.md if you have **genuinely reusable knowledge** that would he
 
 See **[docs/learnable-patterns.md](./learnable-patterns.md)** for the complete guide on identifying and capturing reusable patterns, including how to use `progress.txt` for lightweight patterns and when to create documentation PRs.
 
-## Browser Testing (If Available)
+## Browser Testing
 
-For any story that changes UI, verify it works in the browser if you have browser testing tools configured (e.g., via MCP):
-
-1. Navigate to the relevant page
-2. Verify the UI changes work as expected
-3. Take a screenshot if helpful for the progress log
-
-If no browser tools are available, note in your progress report that manual browser verification is needed.
+Browser testing is not a separate, optional step — it is the **browser-verifiable** branch of the
+mandatory verification triage in **step 6b** above. Define the test plan, classify testability,
+and (for browser-verifiable stories) drive the change in a real browser via the `browser-verify`
+skill, recording the Verification block. If browser tools are unavailable for a story you judged
+browser-verifiable, record that manual browser verification is still needed rather than silently
+relying on tests alone.

--- a/run.sh
+++ b/run.sh
@@ -116,8 +116,14 @@ if [[ "$GIT_REPO" != /* ]]; then
   GIT_REPO="$PARENT_ROOT/$GIT_REPO"
 fi
 
+# Helper that manages the throwaway remote-debuggable Brave for browser verification
+DEBUG_BROWSER_SCRIPT="$SCRIPT_DIR/scripts/launch-brave-debug.sh"
+
 # Function to switch back to master branch on exit
 cleanup_and_return_to_master() {
+  # Best-effort: tear down any debug browser this run started so we never leak it.
+  "$DEBUG_BROWSER_SCRIPT" stop >/dev/null 2>&1 || true
+
   if [ -n "$GIT_REPO" ] && [ -d "$GIT_REPO/.git" ]; then
     echo ""
     echo "Switching back to $BOT_DEFAULT_BRANCH branch in $GIT_REPO..."
@@ -219,6 +225,23 @@ while [ $loop_count -lt $MAX_ITERATIONS ]; do
   STORY_DETAILS=$(echo "$TASK_JSON" | jq -c '.storyDetails')
   echo "Selected: $STORY_ID - $STORY_TITLE (status: $STORY_STATUS, tier: $TIER_NAME)"
 
+  # Browser verification: a story opts in with "browserVerify": true. When set,
+  # bring up a remote-debuggable Brave on 9223 BEFORE the Claude session starts,
+  # so chrome-devtools-mcp (which attaches at session start) can drive it.
+  # Best-effort: if the browser can't start, log it and run without verification
+  # rather than failing the whole iteration.
+  BROWSER_VERIFY=$(echo "$STORY_DETAILS" | jq -r '.browserVerify // false' 2>/dev/null || echo "false")
+  BROWSER_STARTED=false
+  if [ "$BROWSER_VERIFY" = "true" ]; then
+    echo "Story opts into browser verification — starting debug Brave on 9223..."
+    if "$DEBUG_BROWSER_SCRIPT" start >>"$ITERATION_LOG" 2>&1; then
+      BROWSER_STARTED=true
+      echo "Debug Brave is up; chrome-devtools-mcp can attach."
+    else
+      echo "Warning: could not start debug Brave — running WITHOUT browser verification."
+    fi
+  fi
+
   # Task confirmed — proceed with iteration setup
   # Store the current iteration log path in run-state.json
   TMP_RUN_STATE=$(mktemp)
@@ -293,6 +316,16 @@ Nightly version: $NIGHTLY_VERSION (use this for milestone names like '$NIGHTLY_V
 
 Additional context: $EXTRA_PROMPT"
   fi
+  if [ "$STORY_STATUS" = "pending" ]; then
+    AGENT_PROMPT="$AGENT_PROMPT
+
+Before marking development complete you MUST define a test plan and verify the fix (workflow-pending.md step 6b): write a concrete test plan from the acceptance criteria, triage testability into one of browser-verifiable / automated-test-only / not-verifiable-here, verify the change through the strongest available means, and record the Verification block in the pending → committed progress.txt entry. Passing the acceptance-criteria tests alone is not sufficient — you must also state how the fix was observed to work, or explicitly why it cannot be verified in this environment (never fake a PASS)."
+  fi
+  if [ "$BROWSER_STARTED" = "true" ]; then
+    AGENT_PROMPT="$AGENT_PROMPT
+
+Browser verification is ENABLED for this story. A remote-debuggable build of the locally-built dev Brave is running at http://127.0.0.1:9223 and the chrome-devtools MCP is attached to it. Before you mark development complete, you MUST functionally verify the change in the browser by invoking the browser-verify skill, which defines a test plan, drives the browser via the chrome-devtools MCP, and records a PASS/FAIL verdict in the Browser Verification block of the pending → committed progress.txt template. The Verdict must be PASS before committing — if the feature does not behave as specified, the story is NOT done."
+  fi
 
   # Log the prompt to the iteration log so it can be audited later
   if [ "$USE_TUI" != true ]; then
@@ -326,6 +359,13 @@ Additional context: $EXTRA_PROMPT"
     else
       (cd "$SCRIPT_DIR" && "$SCRIPT_DIR/scripts/timeout-tree.sh" 7200 $BOT_CLAUDE_BIN $CLAUDE_MODEL_FLAG --dangerously-skip-permissions --print --verbose --output-format stream-json --session-id "$SESSION_ID" "$AGENT_PROMPT") 200>&- </dev/null 2>&1 | tee -a "$ITERATION_LOG" > "$TEMP_OUTPUT" || true
     fi
+  fi
+
+  # Tear down the debug browser if we started one for this iteration (the exit
+  # trap also calls stop, but doing it here frees port 9223 between iterations).
+  if [ "$BROWSER_STARTED" = "true" ]; then
+    "$DEBUG_BROWSER_SCRIPT" stop >/dev/null 2>&1 || true
+    BROWSER_STARTED=false
   fi
 
   if [ "$BOT_AGENT" = "claude" ]; then

--- a/scripts/launch-brave-debug.sh
+++ b/scripts/launch-brave-debug.sh
@@ -1,0 +1,205 @@
+#!/bin/bash
+# Manage a throwaway, remote-debuggable Brave instance for test-plan verification.
+#
+# This is an INTERNAL helper invoked by run.sh — not meant to be run by hand in
+# normal operation. run.sh calls `start` before a browser-verifiable story's
+# Claude session (so chrome-devtools-mcp can attach) and `stop` after.
+#
+# chrome-devtools-mcp is configured (in ~/.claude.json) with
+#   --browserUrl http://127.0.0.1:9223
+# and attaches to an ALREADY-RUNNING browser at session start. So the browser
+# must be up and serving the /json discovery endpoints BEFORE the Claude
+# session starts — that is what `start` guarantees (it blocks until
+# /json/version responds).
+#
+# Port 9223 (NOT 9222) is intentional: 9222 is the default people use for their
+# daily Brave/Chrome. A dedicated port keeps this throwaway dev Brave from
+# colliding with whatever browser you already have open.
+#
+# IMPORTANT: the browser MUST be launched WITH --remote-debugging-port (done
+# below). The chrome://inspect "Allow remote debugging" toggle ALONE is not
+# enough — it exposes a WebSocket but the HTTP /json discovery endpoints return
+# 404, and chrome-devtools-mcp needs /json/version to find the browser.
+#
+# Usage:
+#   ./scripts/launch-brave-debug.sh start [start_url]   # launch (bg), wait until ready
+#   ./scripts/launch-brave-debug.sh stop                # kill the instance we started
+#   ./scripts/launch-brave-debug.sh status              # 0 if reachable, 1 otherwise
+#
+# Exit codes for `start`: 0 = ready (newly launched or already running),
+#                         1 = could not start (binary missing, port held by a
+#                             non-debuggable process, or never became ready).
+#
+# Notes:
+# - Uses a throwaway --user-data-dir so it never touches your real Brave profile.
+# - --autoConnect cannot be used because it only finds official Google Chrome.
+
+set -e
+
+DEBUG_PORT=9223
+DEBUG_HOST=127.0.0.1
+PROFILE_DIR="${TMPDIR:-/tmp}/brave-debug-profile"
+PIDFILE="$PROFILE_DIR/debug-brave.pid"
+READY_URL="http://$DEBUG_HOST:$DEBUG_PORT/json/version"
+READY_TIMEOUT=120  # seconds to wait for /json/version after launch. Generous because
+                   # the FIRST launch of a freshly-built .app triggers a macOS code-sign
+                   # clone of the whole bundle (code_sign_clone_manager) that can take
+                   # well over 30s; the poll exits early once ready, so warm launches
+                   # still return in ~3s.
+
+# Load bot config so we can resolve the Brave binary per-machine (no hardcoded path).
+SELF_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=/dev/null
+source "$SELF_DIR/lib/load-config.sh" 2>/dev/null || true
+
+# Resolve the built Brave binary, highest precedence first:
+#   1. BRAVE_BIN env var
+#   2. config.json  ->  browserVerify.braveBinary  (exported as BOT_BRAVE_BIN)
+#   3. auto-detect under the target repo's build output (out/<config>/...)
+# Echoes the resolved path on stdout; returns non-zero if none found.
+resolve_brave_bin() {
+  # 1. explicit env override
+  if [ -n "${BRAVE_BIN:-}" ]; then
+    printf '%s\n' "$BRAVE_BIN"
+    return 0
+  fi
+  # 2. configured path
+  if [ -n "${BOT_BRAVE_BIN:-}" ]; then
+    printf '%s\n' "$BOT_BRAVE_BIN"
+    return 0
+  fi
+  # 3. auto-detect from the target repo's build output
+  local repo="${BOT_TARGET_REPO_PATH:-}"
+  [ -n "$repo" ] || return 1
+  case "$repo" in
+    /*) ;;
+    *) repo="$(cd "${BOT_DIR:-$SELF_DIR/..}/.." 2>/dev/null && pwd)/$repo" ;;
+  esac
+  # brave-core sits at <chromium_src>/src/brave; the build output is at <...>/src/out.
+  local out_root=""
+  if [ -d "$repo/out" ]; then
+    out_root="$repo/out"
+  elif [ -d "$(dirname "$repo")/out" ]; then
+    out_root="$(dirname "$repo")/out"
+  fi
+  [ -n "$out_root" ] || return 1
+  local found
+  # macOS: the main .app bundle for any channel (Development/Beta/Nightly/Brave Browser).
+  # The binary sits 5 levels under out/ (<config>/X.app/Contents/MacOS/<name>), so search
+  # to depth 6. Exclude the "... Helper" bundles (Renderer/GPU/Alerts) — we want the main app.
+  found=$(find "$out_root" -maxdepth 6 -type f -path '*.app/Contents/MacOS/*Browser*' 2>/dev/null \
+            | grep -v 'Helper' | head -1)
+  # Linux: a bare `brave` executable directly under out/<config>/.
+  [ -n "$found" ] || found=$(find "$out_root" -maxdepth 2 -type f -name 'brave' -perm -u+x 2>/dev/null | head -1)
+  [ -n "$found" ] || return 1
+  printf '%s\n' "$found"
+}
+
+# True if the debug endpoint is reachable (browser up AND serving /json).
+is_ready() {
+  curl -fsS --max-time 2 "$READY_URL" >/dev/null 2>&1
+}
+
+cmd_status() {
+  if is_ready; then
+    echo "Debug Brave is reachable at $READY_URL"
+    return 0
+  fi
+  echo "Debug Brave is NOT reachable at $READY_URL"
+  return 1
+}
+
+cmd_start() {
+  local start_url="${1:-about:blank}"
+
+  # Idempotent: if something is already serving /json on the port, reuse it.
+  if is_ready; then
+    echo "Debug Brave already reachable at $READY_URL — reusing it."
+    return 0
+  fi
+
+  # Port held but NOT serving /json (e.g. a real Brave with only the toggle on,
+  # or a stale process). We can't drive that reliably — fail loudly.
+  if lsof -nP -iTCP:"$DEBUG_PORT" -sTCP:LISTEN >/dev/null 2>&1; then
+    echo "Error: port $DEBUG_PORT is in use but $READY_URL is not responding." >&2
+    echo "Something is holding the port without serving the debug endpoints." >&2
+    echo "Free it first: lsof -nP -iTCP:$DEBUG_PORT -sTCP:LISTEN" >&2
+    return 1
+  fi
+
+  local brave_bin
+  brave_bin="$(resolve_brave_bin || true)"
+  if [ -z "$brave_bin" ] || [ ! -x "$brave_bin" ]; then
+    echo "Error: could not find a built Brave binary to launch." >&2
+    [ -n "$brave_bin" ] && echo "  Resolved to a non-executable path: $brave_bin" >&2
+    echo "Set it one of these ways (highest precedence first):" >&2
+    echo "  1. export BRAVE_BIN=\"/path/to/Brave Browser <Channel>.app/Contents/MacOS/Brave Browser <Channel>\"" >&2
+    echo "  2. config.json: \"browserVerify\": { \"braveBinary\": \"/path/to/...\" }" >&2
+    echo "  3. build Brave so it appears under <targetRepoPath>/../out/<config>/ (auto-detected)" >&2
+    return 1
+  fi
+
+  mkdir -p "$PROFILE_DIR"
+
+  echo "Launching debug Brave on port $DEBUG_PORT (profile: $PROFILE_DIR, throwaway)"
+  echo "  binary: $brave_bin"
+  "$brave_bin" \
+    --remote-debugging-port="$DEBUG_PORT" \
+    --user-data-dir="$PROFILE_DIR" \
+    --no-first-run \
+    --no-default-browser-check \
+    "$start_url" >/dev/null 2>&1 &
+  local pid=$!
+  echo "$pid" > "$PIDFILE"
+
+  # Block until the discovery endpoint responds (that's what MCP needs), or time out.
+  local waited=0
+  while [ "$waited" -lt "$READY_TIMEOUT" ]; do
+    if is_ready; then
+      echo "Debug Brave ready at $READY_URL (pid $pid)"
+      return 0
+    fi
+    # Bail early if the process died (e.g. crashed on launch).
+    if ! kill -0 "$pid" 2>/dev/null; then
+      echo "Error: debug Brave (pid $pid) exited before becoming ready." >&2
+      rm -f "$PIDFILE"
+      return 1
+    fi
+    sleep 1
+    waited=$((waited + 1))
+  done
+
+  echo "Error: debug Brave did not serve $READY_URL within ${READY_TIMEOUT}s." >&2
+  kill "$pid" 2>/dev/null || true
+  rm -f "$PIDFILE"
+  return 1
+}
+
+cmd_stop() {
+  if [ -f "$PIDFILE" ]; then
+    local pid
+    pid="$(cat "$PIDFILE" 2>/dev/null || true)"
+    if [ -n "$pid" ] && kill -0 "$pid" 2>/dev/null; then
+      echo "Stopping debug Brave (pid $pid)"
+      kill "$pid" 2>/dev/null || true
+      # Give it a moment, then force if still alive.
+      sleep 1
+      kill -9 "$pid" 2>/dev/null || true
+    fi
+    rm -f "$PIDFILE"
+  else
+    echo "No pidfile at $PIDFILE — nothing started by this script to stop."
+  fi
+  # Remove the throwaway profile so each run starts clean.
+  rm -rf "$PROFILE_DIR" 2>/dev/null || true
+}
+
+case "${1:-start}" in
+  start)  shift || true; cmd_start "$@" ;;
+  stop)   cmd_stop ;;
+  status) cmd_status ;;
+  *)
+    echo "Usage: $0 {start [url] | stop | status}" >&2
+    exit 2
+    ;;
+esac

--- a/scripts/lib/load-config.sh
+++ b/scripts/lib/load-config.sh
@@ -52,6 +52,10 @@ BOT_CODEX_BIN=$(bot_config '.bot.codexBin')
 
 BOT_BP_DOCS_DIR=$(bot_config '.bestPractices.docsDir')
 
+# Optional: explicit path to the built Brave binary for browser verification.
+# Empty by default — launch-brave-debug.sh falls back to auto-detection.
+BOT_BRAVE_BIN=$(bot_config '.browserVerify.braveBinary')
+
 # Validate required fields
 _missing=""
 [ -z "$BOT_PROJECT_NAME" ] && _missing="$_missing project.name"
@@ -87,4 +91,5 @@ export BOT_DIR BOT_CONFIG_FILE
 export BOT_PROJECT_NAME BOT_ORG BOT_PR_REPO BOT_ISSUE_REPO BOT_DEFAULT_BRANCH BOT_TARGET_REPO_PATH
 export BOT_USERNAME BOT_EMAIL
 export BOT_AGENT BOT_CLAUDE_MODEL BOT_CLAUDE_BIN BOT_CODEX_MODEL BOT_CODEX_BIN
+export BOT_BRAVE_BIN
 export BOT_BP_DOCS_DIR


### PR DESCRIPTION
Adds a mandatory verification step to the bot's `pending` workflow: before a story can move to `committed`, the bot must define a test plan, verify the fix through the strongest means available in the environment, and record the outcome in `progress.txt`. For user-facing stories that means functionally driving a real dev Brave via the [`chrome-devtools` MCP](https://github.com/ChromeDevTools/chrome-devtools-mcp) — passing the acceptance-criteria tests alone is no longer sufficient.

## How it works

**1. Verification triage (every pending story).** `docs/workflow-pending.md` step 6b requires the bot to write a concrete test plan from the acceptance criteria and classify the story into exactly one bucket:

- `browser-verifiable` — observable in a running browser (WebUI/settings, page behavior, rendering). → drive it in a real browser.
- `automated-test-only` — not observable by driving the browser but fully covered by unit/browser tests. → those tests *are* the verification.
- `not-verifiable-here` — needs another OS/hardware/platform (e.g. a Windows-only bug). → don't fake a result; record why and flag that manual verification is still needed.

The result is appended as a `Verification` block (see `docs/progress-reporting.md`) with a `PASS` / `FAIL` / `NOT-VERIFIABLE-HERE` verdict. The bot is explicitly told never to rationalize a near-miss into a PASS.

**2. Browser lifecycle (`run.sh` + `scripts/launch-brave-debug.sh`).** A story opts into the browser path with `"browserVerify": true`. When set, `run.sh`:
- calls `launch-brave-debug.sh start` *before* the Claude session, which launches a throwaway, remote-debuggable dev Brave on `http://127.0.0.1:9223` (a dedicated port so it never collides with a daily browser on 9222) and blocks until the `/json/version` discovery endpoint responds;
- runs the session with the `chrome-devtools` MCP attached to that browser, and appends the verification-step guidance to the prompt;
- calls `launch-brave-debug.sh stop` afterward (and in the EXIT trap) to tear it down.

It's best-effort: if the dev binary is missing or the browser can't start, `run.sh` logs a warning and runs without browser verification rather than failing the iteration. The launch script is an internal helper — it's never meant to be run by hand.

**3. The `browser-verify` skill** is the canonical browser procedure (single source of truth that `run.sh` and step 6b both delegate to): confirm the story is actually browser-verifiable, ensure a debuggable Brave is up (reuse or start), define a test plan, drive the browser via the MCP, judge PASS/FAIL, record the verdict, and stop the browser only if it started it.

## Notes

- The browser uses a throwaway `--user-data-dir`, so there's no reliance on existing logins or profile state.
- `READY_TIMEOUT` is 120s: the first launch of a freshly built `.app` triggers a macOS code-sign clone of the whole bundle that can exceed 30s; the readiness poll still exits early, so warm launches return in ~3s.
- Brave binary resolution is per-machine (no hardcoded path): `BRAVE_BIN` env → `config.json` `browserVerify.braveBinary` → auto-detect under the target repo's build output.
