### PR TITLE
Add bug discovery

### DIFF
--- a/.claude/skills/discover-bugs/PODS.md
+++ b/.claude/skills/discover-bugs/PODS.md
@@ -1,0 +1,62 @@
+# Bug-scan pods
+
+> **Generated from `pods.json` — do not edit by hand.**
+> Edit `pods.json` and run `python3 prepare-scan.py --sync-doc` to regenerate.
+
+Target repo: **brave-core** · branch: **master**.
+
+Each pod below is one scan task: its own cron job and its own subagent. A pod sweeps its **entire tree** on master as full source (never diffs), bounded per run and rotating across runs until the whole tree is covered; then it idles for a cooldown and re-scans the whole codebase again. Findings are prioritized (P0/P1/P2) and filed as `ai-generated` issues for human confirmation.
+
+**22 scan tasks:**
+
+| # | Pod id | Area | Paths |
+| - | ------ | ---- | ----- |
+| 1 | `ai-chat` | AI Chat / Leo | `components/ai_chat/*`<br>`browser/ai_chat/*` |
+| 2 | `wallet-ethereum` | Wallet — Ethereum/EVM | `components/brave_wallet/browser/eth_*`<br>`components/brave_wallet/browser/eip*`<br>`components/brave_wallet/browser/ethereum_*` |
+| 3 | `wallet-solana` | Wallet — Solana | `components/brave_wallet/browser/solana*` |
+| 4 | `wallet-bitcoin` | Wallet — Bitcoin | `components/brave_wallet/browser/bitcoin/*` |
+| 5 | `wallet-zcash` | Wallet — Zcash | `components/brave_wallet/browser/zcash/*` |
+| 6 | `wallet-other-chains` | Wallet — Cardano/Polkadot/Filecoin/internal | `components/brave_wallet/browser/cardano/*`<br>`components/brave_wallet/browser/polkadot/*`<br>`components/brave_wallet/browser/internal/*`<br>`components/brave_wallet/browser/filecoin_*`<br>`components/brave_wallet/browser/fil_*` |
+| 7 | `wallet-keyring` | Wallet — Keyring / key management | `components/brave_wallet/browser/*keyring*` |
+| 8 | `wallet-core` | Wallet — Core services & UI | `components/brave_wallet/*`<br>`components/brave_wallet_ui/*`<br>`browser/brave_wallet/*` |
+| 9 | `shields` | Shields (content settings, blocking core) | `components/brave_shields/*`<br>`browser/brave_shields/*` |
+| 10 | `adblock` | Adblock component | `components/brave_shields/core/browser/ad_block_*`<br>`components/brave_shields/core/browser/adblock*`<br>`components/brave_adblock_ui/*`<br>`components/brave_shields/content/*ad_block*` |
+| 11 | `fingerprinting` | Fingerprinting protection (farbling) | `components/script_injector/*`<br>`components/brave_shields/*farbl*`<br>`components/brave_shields/*fingerprint*` |
+| 12 | `sync` | Sync | `components/brave_sync/*`<br>`components/sync/*`<br>`components/sync_device_info/*`<br>`components/sync_preferences/*`<br>`browser/sync/*` |
+| 13 | `vpn` | VPN | `components/brave_vpn/*`<br>`browser/brave_vpn/*` |
+| 14 | `talk` | Talk | `components/brave_talk/*`<br>`components/brave_new_tab_ui/components/default/braveTalk/*`<br>`ios/browser/brave_talk/*` |
+| 15 | `talk-premium` | Talk Premium / SKUs entitlement | `components/skus/*`<br>`browser/skus/*` |
+| 16 | `news` | News | `components/brave_news/*`<br>`browser/brave_news/*` |
+| 17 | `sidebar` | Sidebar | `components/sidebar/*`<br>`browser/ui/sidebar/*` |
+| 18 | `speedreader` | Speedreader | `components/speedreader/*`<br>`browser/speedreader/*` |
+| 19 | `tor` | Tor | `components/tor/*`<br>`browser/tor/*` |
+| 20 | `wayback-machine` | Wayback Machine | `components/brave_wayback_machine/*` |
+| 21 | `web-discovery` | Web Discovery | `components/web_discovery/*`<br>`browser/web_discovery/*` |
+| 22 | `email-aliases` | Email Aliases | `components/email_aliases/*`<br>`browser/email_aliases/*` |
+
+## Focus per pod
+
+- **AI Chat / Leo** (`ai-chat`): Conversation state lifetime, streaming response handling, untrusted model/server output parsing, tab-content extraction, feature-flag gating.
+- **Wallet — Ethereum/EVM** (`wallet-ethereum`): EVM tx construction/signing, ABI decode bounds, nonce/gas math integer over/underflow, RPC response parsing, allowance handling.
+- **Wallet — Solana** (`wallet-solana`): Instruction/message compilation bounds, account-meta indexing, signature/serialization correctness, untrusted RPC parsing.
+- **Wallet — Bitcoin** (`wallet-bitcoin`): UTXO selection/amount math over/underflow, PSBT/tx serialization bounds, key derivation, block-tracker lifetime.
+- **Wallet — Zcash** (`wallet-zcash`): Shielded/transparent tx math, orchard/librustzcash FFI boundary validation, serialization bounds, amount over/underflow.
+- **Wallet — Cardano/Polkadot/Filecoin/internal** (`wallet-other-chains`): Chain-specific tx/amount math, serialization bounds, FFI/internal boundary validation, key handling.
+- **Wallet — Keyring / key management** (`wallet-keyring`): Seed/private-key lifetime and zeroing, mnemonic handling, keyring migration correctness, unlock/lock state, password handling.
+- **Wallet — Core services & UI** (`wallet-core`): Service/factory object lifetime, mojo/IPC validation of renderer-supplied values, asset/price parsing, permission checks, WeakPtr use-after-invalidate.
+  - excludes: `components/brave_wallet/browser/eth_*`, `components/brave_wallet/browser/eip*`, `components/brave_wallet/browser/ethereum_*`, `components/brave_wallet/browser/solana*`, `components/brave_wallet/browser/bitcoin/*`, `components/brave_wallet/browser/zcash/*`, `components/brave_wallet/browser/cardano/*`, `components/brave_wallet/browser/polkadot/*`, `components/brave_wallet/browser/internal/*`, `components/brave_wallet/browser/filecoin_*`, `components/brave_wallet/browser/fil_*`, `components/brave_wallet/browser/*keyring*`
+- **Shields (content settings, blocking core)** (`shields`): Content-settings resolution correctness, per-site rule application, cross-thread access to shields state, null pref/host-content-settings reads.
+  - excludes: `components/brave_shields/core/browser/ad_block_*`, `components/brave_shields/core/browser/adblock*`, `components/brave_shields/*farbl*`, `components/brave_shields/*fingerprint*`
+- **Adblock component** (`adblock`): Filter-list provider lifetime, component/DAT loading and parsing bounds, engine update races, untrusted rule/resource parsing.
+- **Fingerprinting protection (farbling)** (`fingerprinting`): Farbling seed derivation, script injection into untrusted frames, per-origin randomization consistency, renderer-side value validation.
+- **Sync** (`sync`): Sync record encode/decode of untrusted server data, crypto/nudge handling, device-info lifetime, cross-sequence access, migration correctness.
+- **VPN** (`vpn`): Connection state machine correctness, credential/subscription handling, region-list parsing of server data, connection-observer lifetime.
+- **Talk** (`talk`): Talk integration/launch flow, message-handler input validation, native-JS bridge value validation.
+- **Talk Premium / SKUs entitlement** (`talk-premium`): SKU/entitlement verification that gates Talk & VPN premium, credential/order-state parsing of server responses, expiry math, replay/forgery of entitlement state.
+- **News** (`news`): Feed/publisher parsing of untrusted network data, image/URL handling, feed-controller lifetime, cross-thread feed updates.
+- **Sidebar** (`sidebar`): Sidebar item model lifetime vs UI, tab/browser observer teardown, null browser/webcontents reads, item ordering correctness.
+- **Speedreader** (`speedreader`): Distillation of untrusted page content, throttle/delegate lifetime, renderer boundary validation, null document reads.
+- **Tor** (`tor`): Tor process/launcher lifetime, control-port parsing, proxy config correctness, profile teardown, leaking identifiers across sessions.
+- **Wayback Machine** (`wayback-machine`): Wayback API response parsing, infobar/delegate lifetime vs webcontents, null response handling, URL validation.
+- **Web Discovery** (`web-discovery`): Untrusted page/content extraction and reporting, anonymization/hashing correctness, scheduler/observer lifetime, PII leakage in payloads.
+- **Email Aliases** (`email-aliases`): Alias service state, server-response parsing, auth/session handling, mojo/IPC validation, alias-list lifetime.

--- a/.claude/skills/discover-bugs/SKILL.md
+++ b/.claude/skills/discover-bugs/SKILL.md
@@ -1,0 +1,107 @@
+---
+name: discover-bugs
+description: "Scan the target repo for likely bugs (lifetime/UAF, threading, null-deref, mojo/IPC, uninitialized) over recently-changed code, verify them, and either report locally or file ai-generated GitHub issues for human confirmation. Triggers on: discover bugs, scan for bugs, bug scan, find bugs in code."
+argument-hint: "[--since-cache|--commits N|--days N] [auto] [file-issues]"
+allowed-tools: Bash
+---
+
+# Discover Bugs (static scan)
+
+Bounded, verify-first static scan of the target repository for concrete
+defects. Findings are **not** auto-fixed — they are reported for a human to
+confirm. Confirmed issues then flow through the normal pipeline
+(`add-backlog-to-prd` → `run.sh`).
+
+**Default output is a local report only.** Issue filing to the configured issue
+repository (`gh issue create --label ai-generated`) happens ONLY when invoked
+with the `file-issues` argument, so the tracker is never spammed while scan
+quality is still being tuned.
+
+**NEVER** @-mention or tag anyone in a filed issue (repo rule). The
+`ai-generated` label is the sole provenance signal.
+
+---
+
+## Architecture: file-based pipeline (mirrors review-prs)
+
+All heavy data goes through files, not the LLM context:
+
+1. **prepare-scan.py** (zero LLM tokens) — selects changed source files, writes
+   one subagent prompt file per chunk, emits a manifest.
+2. **Subagents** (subagent tokens only) — each reads its prompt file, reads the
+   real source to CONFIRM each finding, writes a results JSON file.
+3. **collect-findings.py** (zero LLM tokens) — confidence gate, dedup, then
+   local report or issue filing; updates the scan cache.
+
+---
+
+## The Job
+
+When invoked with `/discover-bugs [--since-cache|--commits N|--days N] [auto] [file-issues]`:
+
+### Step 1: Prepare (zero LLM tokens)
+
+```bash
+BOT_DIR="<absolute path to brave-dev-bot directory>"
+python3 $BOT_DIR/.claude/skills/discover-bugs/prepare-scan.py [--since-cache|--commits N|--days N]
+```
+
+Default window is `--since-cache` (diff since the last scan; falls back to the
+last 7 days on first run). Stdout is a tiny JSON: `{"work_dir":..., "manifest":...}`.
+Parse it to get `work_dir`.
+
+### Step 2: Read manifest
+
+Read `{work_dir}/manifest.json`. Print its `progress_lines` (for cron logs). Key
+fields: `chunks` (each has `prompt_file` + `results_file`), `issue_repo`,
+`target_repo_path`, `capped` (log the warning if true — files were dropped).
+
+If `chunks` is empty, skip to Step 4 (nothing changed).
+
+### Step 3: Launch subagents
+
+For every chunk, launch a **Task subagent** (`subagent_type: "general-purpose"`)
+with this prompt — **launch ALL chunks in a single message** so they run
+concurrently:
+
+```
+Read your full scan instructions from: {prompt_file}
+Execute them completely. Read the referenced source files under the target repo
+to CONFIRM each finding before reporting it. Report ONLY confidence:high bugs.
+Write your results JSON to the exact path named in the instructions.
+```
+
+Wait for all subagents to return. Do NOT file issues or write reports yourself —
+that is Step 4's job.
+
+### Step 4: Collect (zero LLM tokens)
+
+```bash
+python3 $BOT_DIR/.claude/skills/discover-bugs/collect-findings.py --work-dir "$WORK_DIR" [--file-issues]
+```
+
+Pass `--file-issues` ONLY if the invocation included the `file-issues` argument
+(or `auto file-issues` in cron once quality is proven). Otherwise it writes a
+local report to `logs/discover-bugs-<stamp>.md` and files nothing.
+
+Read the script's stderr summary and print it for cron logs.
+
+---
+
+## Modes
+
+- **default (report-only):** `/discover-bugs` — scan, verify, write local report.
+- **file issues:** `/discover-bugs file-issues` — additionally file
+  `ai-generated` issues for fresh high-confidence findings.
+- **cron/headless:** `/discover-bugs --since-cache auto` — report-only by
+  default; add `file-issues` to the cron args only after the false-positive rate
+  is acceptable.
+
+## Guardrails
+
+- Report ONLY `confidence:high` findings (collect-findings enforces this).
+- Dedup against the local seen-list AND open `ai-generated` issues — never
+  re-file the same bug.
+- Never auto-fix. Never @-mention. Never merge.
+- `--max-files` caps work per run; the manifest logs anything dropped (no silent
+  truncation).

--- a/.claude/skills/discover-bugs/SKILL.md
+++ b/.claude/skills/discover-bugs/SKILL.md
@@ -1,21 +1,40 @@
 ---
 name: discover-bugs
-description: "Scan the target repo for likely bugs (lifetime/UAF, threading, null-deref, mojo/IPC, uninitialized) over recently-changed code, verify them, and either report locally or file ai-generated GitHub issues for human confirmation. Triggers on: discover bugs, scan for bugs, bug scan, find bugs in code."
-argument-hint: "[--since-cache|--commits N|--days N] [auto] [file-issues]"
+description: "Scan the target repo for likely bugs (lifetime/UAF, threading, null/bounds, integer over-underflow, stack overflow, mojo/IPC, security/crypto, logic errors) per product/pod, verify them, prioritize (P0/P1/P2), and file ai-generated GitHub issues for human confirmation. Triggers on: discover bugs, scan for bugs, bug scan, find bugs in code."
+argument-hint: "[--pod <id> | --since-cache|--commits N|--days N] [auto] [file-issues]"
 allowed-tools: Bash
 ---
 
 # Discover Bugs (static scan)
 
-Bounded, verify-first static scan of the target repository for concrete
-defects. Findings are **not** auto-fixed — they are reported for a human to
-confirm. Confirmed issues then flow through the normal pipeline
-(`add-backlog-to-prd` → `run.sh`).
+Bounded, verify-first static scan of the target repository (**brave-core**,
+**master** only) for concrete defects. Findings are **not** auto-fixed — they
+are reported for a human to confirm. Confirmed issues then flow through the
+normal pipeline (`add-backlog-to-prd` → `run.sh`).
 
-**Default output is a local report only.** Issue filing to the configured issue
-repository (`gh issue create --label ai-generated`) happens ONLY when invoked
-with the `file-issues` argument, so the tracker is never spammed while scan
-quality is still being tuned.
+## Two ways to scope a scan
+
+- **Pod mode (`--pod <id>`)** — the primary mode. Scans ONE product/pod defined
+  in `pods.json` (AI Chat/Leo, Wallet split by chain/keyring/core, Shields,
+  Adblock, Fingerprinting, Sync, VPN, Talk, Talk Premium/SKUs, News, Sidebar,
+  Speedreader, Tor, Wayback, Web Discovery, Email Aliases). Each pod is its own
+  cron job and its own subagent, so a run works exactly one task. See
+  [PODS.md](PODS.md) (generated from `pods.json`).
+  - **Full-codebase, cyclic:** a pod scans its **entire tree** on master as
+    full source (never diffs) — bounded per run, rotating across runs via a
+    cursor in `.ignore/discover-bugs/<pod>.json` until the whole tree is covered.
+    When the sweep completes the pod idles for a cooldown
+    (`--rescan-days`, default 14; per-pod `rescan_interval_days` in `pods.json`),
+    then re-scans the whole codebase again. There is **no changed-only phase**.
+- **Legacy mode (no `--pod`)** — repo-wide diff of recently-changed files
+  (`--since-cache|--commits N|--days N`). Kept for ad-hoc use.
+
+## Prioritization
+
+`collect-findings.py` scores every surviving finding by severity + bug class
+(memory-safety/security/crypto/IPC classes get a bump) into **P0/P1/P2**, sorts
+by priority, and puts the tier in the issue title (`[ai-bug][P0][<pod>] …`) and
+body.
 
 **NEVER** @-mention or tag anyone in a filed issue (repo rule). The
 `ai-generated` label is the sole provenance signal.
@@ -26,8 +45,8 @@ quality is still being tuned.
 
 All heavy data goes through files, not the LLM context:
 
-1. **prepare-scan.py** (zero LLM tokens) — selects changed source files, writes
-   one subagent prompt file per chunk, emits a manifest.
+1. **prepare-scan.py** (zero LLM tokens) — selects the next slice of source
+   files to scan, writes one subagent prompt file per chunk, emits a manifest.
 2. **Subagents** (subagent tokens only) — each reads its prompt file, reads the
    real source to CONFIRM each finding, writes a results JSON file.
 3. **collect-findings.py** (zero LLM tokens) — confidence gate, dedup, then
@@ -37,18 +56,23 @@ All heavy data goes through files, not the LLM context:
 
 ## The Job
 
-When invoked with `/discover-bugs [--since-cache|--commits N|--days N] [auto] [file-issues]`:
+When invoked with `/discover-bugs [--pod <id> | --since-cache|--commits N|--days N] [auto] [file-issues]`:
 
 ### Step 1: Prepare (zero LLM tokens)
 
 ```bash
 BOT_DIR="<absolute path to brave-dev-bot directory>"
+# Pod mode (primary):
+python3 $BOT_DIR/.claude/skills/discover-bugs/prepare-scan.py --pod <id>
+# Legacy mode:
 python3 $BOT_DIR/.claude/skills/discover-bugs/prepare-scan.py [--since-cache|--commits N|--days N]
 ```
 
-Default window is `--since-cache` (diff since the last scan; falls back to the
-last 7 days on first run). Stdout is a tiny JSON: `{"work_dir":..., "manifest":...}`.
-Parse it to get `work_dir`.
+In pod mode the script auto-selects the next full-sweep slice from the pod's
+cache (or emits an empty batch while the pod is in its re-scan cooldown). Legacy
+default is `--since-cache` (diff since the last scan; falls back to last 7 days
+on first run). Stdout is a tiny JSON: `{"work_dir":..., "manifest":...}`. Parse
+it to get `work_dir`.
 
 ### Step 2: Read manifest
 
@@ -56,12 +80,16 @@ Read `{work_dir}/manifest.json`. Print its `progress_lines` (for cron logs). Key
 fields: `chunks` (each has `prompt_file` + `results_file`), `issue_repo`,
 `target_repo_path`, `capped` (log the warning if true — files were dropped).
 
-If `chunks` is empty, skip to Step 4 (nothing changed).
+If `chunks` is empty, skip to Step 4 (sweep complete and still in cooldown —
+nothing to scan this run).
 
 ### Step 3: Launch subagents
 
 For every chunk, launch a **Task subagent** (`subagent_type: "general-purpose"`)
-with this prompt — **launch ALL chunks in a single message** so they run
+**on a cheap model** — pass `model: "claude-haiku-4-5"` (or `"claude-sonnet-5"`
+if depth matters more than cost). Bug confirmation is a bounded, well-specified
+task and does NOT need Opus; the model tier is the single biggest cost lever
+(see **Cost** below). **Launch ALL chunks in a single message** so they run
 concurrently:
 
 ```
@@ -90,18 +118,45 @@ Read the script's stderr summary and print it for cron logs.
 
 ## Modes
 
-- **default (report-only):** `/discover-bugs` — scan, verify, write local report.
-- **file issues:** `/discover-bugs file-issues` — additionally file
-  `ai-generated` issues for fresh high-confidence findings.
-- **cron/headless:** `/discover-bugs --since-cache auto` — report-only by
-  default; add `file-issues` to the cron args only after the false-positive rate
-  is acceptable.
+- **pod scan (cron default):** `/discover-bugs --pod <id> auto file-issues` —
+  one pod per cron job (staggered 05:00–12:20 daily, see `sync-schedules.sh`).
+  The gate `scripts/check-pod-candidates.sh <id>` skips the run when the pod has
+  no work (full sweep done and still within the re-scan cooldown).
+- **pod scan (manual, report-only):** `/discover-bugs --pod <id>` — omit
+  `file-issues` to write a local prioritized report without filing.
+- **legacy report-only:** `/discover-bugs` — repo-wide changed-file scan, local
+  report only.
+- **legacy file issues:** `/discover-bugs file-issues`.
+
+To add/remove a pod, edit `pods.json`, run
+`python3 prepare-scan.py --sync-doc` (regenerates `PODS.md`), and re-run
+`scripts/sync-schedules.sh` (installs/updates that pod's cron).
+
+## Cost (tokens)
+
+The scanning subagents are ~all the cost; the orchestrator is negligible. Levers,
+biggest first:
+
+1. **Model tier — dominant.** Scan subagents default to **Haiku** (see Step 3).
+   Haiku vs Opus is a ~10–20× cost cut; Sonnet ~5×. Never scan on Opus.
+2. **Bounded runs.** `--max-files` (default 30) caps files per pod per run.
+   ONE pod per cron, staggered. NEVER bulk-run all pods full-tree at once — that
+   is thousands of subagents in one shot.
+3. **`--files-per-chunk`** (default 5): larger chunks → fewer subagents → less
+   repeated rubric/prompt overhead (each agent reads more, though).
+4. **`--rescan-days`** (default 14): longer cooldown → the whole codebase is
+   re-swept less often.
+
+Rough scale: a single pod-run (30 files, ~6 Haiku subagents) is a few cents to a
+few dollars. A full-tree sweep of every pod at once on Opus is hundreds of
+dollars — do not do it. Keep a workspace spending cap on.
 
 ## Guardrails
 
 - Report ONLY `confidence:high` findings (collect-findings enforces this).
-- Dedup against the local seen-list AND open `ai-generated` issues — never
-  re-file the same bug.
+- Dedup against the per-pod local seen-list AND open `ai-generated` issues —
+  never re-file the same bug (dedup is why full-tree sweeps and re-scan cycles
+  are safe to repeat).
 - Never auto-fix. Never @-mention. Never merge.
-- `--max-files` caps work per run; the manifest logs anything dropped (no silent
-  truncation).
+- `--max-files` caps work per run; sweep progress is tracked by a cursor so
+  nothing is silently dropped — it's scanned on a later run.

--- a/.claude/skills/discover-bugs/USAGE.md
+++ b/.claude/skills/discover-bugs/USAGE.md
@@ -1,0 +1,132 @@
+# discover-bugs — usage cheat-sheet
+
+Static bug scanner for the target repo (**brave-core**, **master**). Per-product/pod,
+verify-first, prioritized (P0/P1/P2), filed as `ai-generated` GitHub issues for a
+human to confirm. Findings are **never auto-fixed**.
+
+## Pipeline (4 steps, same under every run method)
+
+```
+1 prepare-scan.py     0 tokens   pick files -> write chunk prompts -> manifest.json
+2 read manifest       -          parse chunks; if empty -> skip to step 4
+3 subagents (Haiku)   tokens     one subagent per chunk, concurrent -> results JSON
+4 collect-findings.py 0 tokens   gate -> dedup -> prioritize -> report OR file issues -> advance cache
+```
+
+Only step 3 costs tokens. Steps 1 and 4 are deterministic Python (git/glob/gh).
+
+## Two switches that matter
+
+1. **report-only vs file issues** — `file-issues` word (skill) / `--file-issues` (script).
+   Omit = local report only (safe). Present = posts real issues to `brave/brave-browser`.
+2. **scan size per run** — `--max-files` (default 30/pod, cyclic). Default is cheap;
+   cranking it up to sweep a whole pod at once is what makes a run expensive.
+
+---
+
+## Way 1 — skill (interactive, recommended)
+
+```
+/discover-bugs [--pod <id> | --since-cache | --commits N | --days N] [auto] [file-issues]
+```
+
+| word | effect |
+|---|---|
+| `--pod <id>` | pod mode (primary) — scans one pod's whole tree, cyclically |
+| `--since-cache` | legacy: diff since last scan (default when no scope given) |
+| `--commits N` / `--days N` | legacy: files changed in last N commits / days |
+| `auto` | non-interactive (cron) |
+| `file-issues` | file GitHub issues (default: report-only) |
+
+Cases:
+```
+/discover-bugs --pod wayback-machine                 # pod, report-only
+/discover-bugs --pod wayback-machine file-issues     # pod, files issues (outward-facing)
+/discover-bugs --pod ai-chat auto file-issues        # exact cron form
+/discover-bugs                                       # legacy repo-wide, report-only
+/discover-bugs --days 7 file-issues                  # legacy last-7-days, files issues
+```
+
+Report lands in `logs/discover-bugs-<pod>-<stamp>.md`. `--pod` and the legacy scope
+words are mutually exclusive.
+
+Valid pod ids (22): `ai-chat`, `wallet-ethereum`, `wallet-solana`, `wallet-bitcoin`,
+`wallet-zcash`, `wallet-other-chains`, `wallet-keyring`, `wallet-core`, `shields`,
+`adblock`, `fingerprinting`, `sync`, `vpn`, `talk`, `talk-premium`, `news`, `sidebar`,
+`speedreader`, `tor`, `wayback-machine`, `web-discovery`, `email-aliases`.
+
+---
+
+## Way 2 — cron (scheduled, hands-off)
+
+```bash
+bash scripts/sync-schedules.sh   # install/refresh one cron per pod from pods.json
+crontab -l                       # inspect
+```
+
+Each cron line = gate -> git sync -> `claude -p '/discover-bugs --pod <pod> auto file-issues'`
+under a per-pod lock, staggered 05:00-12:20 daily.
+
+- `check-pod-candidates.sh <pod>` gates the run (`prepare-scan.py --pod <pod> --check`);
+  exits 1 -> line stops -> **no tokens when a pod has no work** (sweep done + in cooldown).
+- Change cadence: `rescan_interval_days` in `pods.json`.
+- Add/remove a pod: edit `pods.json`, run `sync-schedules.sh` (and `--sync-doc` for PODS.md).
+
+---
+
+## Way 3 — raw scripts (testing / full control)
+
+**Step 1 — prepare (0 tokens, writes to a temp dir):**
+```bash
+python3 .claude/skills/discover-bugs/prepare-scan.py --pod <id> [flags]
+```
+
+| flag | default | effect |
+|---|---|---|
+| `--pod <id>` | — | pod mode |
+| `--check` | off | gate only: print yes/no, exit 0/1, build nothing |
+| `--sync-doc` | off | regenerate PODS.md from pods.json and exit |
+| `--max-files N` | 30 | hard cap/run (excess picked up next run via cursor) |
+| `--files-per-chunk N` | 5 | files per subagent (larger = fewer agents = cheaper) |
+| `--rescan-days N` | 14 | cooldown after a full sweep before re-sweeping |
+| `--auto` | off | non-interactive marker |
+| `--since-cache`/`--commits N`/`--days N` | — | legacy scope (no `--pod`) |
+
+Output: `{"work_dir": "...", "manifest": "..."}`.
+
+**Step 3 — launch a Haiku subagent per `chunks[].prompt_file`** (from `manifest.json`);
+each reads its prompt, confirms against source, writes its `results_file`.
+
+**Step 4 — collect:**
+```bash
+python3 .claude/skills/discover-bugs/collect-findings.py --work-dir "$WORK_DIR" [--file-issues]
+```
+
+| flag | default | effect |
+|---|---|---|
+| `--work-dir <path>` | required | temp dir from step 1 |
+| `--file-issues` | off | create GitHub issues (default: local report only) |
+
+Zero-cost checks:
+```bash
+python3 .claude/skills/discover-bugs/prepare-scan.py --pod wayback-machine --check
+python3 .claude/skills/discover-bugs/prepare-scan.py --pod wayback-machine --max-files 2 --files-per-chunk 1
+```
+
+---
+
+## Scan model (per pod)
+
+Full-codebase, cyclic: scans the pod's **entire tree** on master as full source
+(never diffs), bounded per run (`--max-files`) and rotating via a cursor in
+`.ignore/discover-bugs/<pod>.json` until the whole tree is covered; then idles for
+`--rescan-days` and re-sweeps. To force a re-scan now: delete that pod's cache file.
+
+## Cautions
+
+- `file-issues` is **outward-facing** — real issues on `brave/brave-browser`
+  (`project.issueRepository`). Test against a throwaway repo first; needs `gh` authed.
+- Scan subagents run on **Haiku** (see SKILL.md step 3) — pennies per pod-chunk.
+  Never bulk-run all pods full-tree on Opus.
+- Dedup (seen-list + open `ai-generated` titles) makes re-runs and re-scan cycles safe.
+- Never auto-fix, never @-mention, never merge.

--- a/.claude/skills/discover-bugs/collect-findings.py
+++ b/.claude/skills/discover-bugs/collect-findings.py
@@ -1,0 +1,224 @@
+#!/usr/bin/env python3
+"""Phase 3 collection for the discover-bugs skill.
+
+Zero-LLM. Reads all subagent result files, applies the confidence gate,
+deduplicates against previously-reported findings and open ai-generated
+issues, then EITHER writes a local report (default) OR files GitHub issues
+labeled `ai-generated` (--file-issues). Updates the scan cache either way.
+
+Usage:
+    python3 collect-findings.py --work-dir DIR [--file-issues]
+
+Default is local-report-only: NO external writes until a human has reviewed
+the scanner's false-positive rate. --file-issues flips on issue creation.
+"""
+
+import argparse
+import hashlib
+import json
+import os
+import re
+import subprocess
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+_SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
+_BOT_DIR = os.path.normpath(os.path.join(_SCRIPT_DIR, "..", "..", ".."))
+sys.path.insert(0, os.path.join(_BOT_DIR, "scripts"))
+
+from lib.load_config import load_config, require_config, get_config
+
+_config = load_config()
+ISSUE_REPO = require_config(_config, "project.issueRepository")
+AI_LABEL = "ai-generated"
+LOGS_DIR = os.path.join(_BOT_DIR, "logs")
+
+
+def log(msg):
+    print(msg, file=sys.stderr)
+
+
+def fingerprint(f):
+    """Stable id for a finding: file + class + normalized title."""
+    title = re.sub(r"\s+", " ", (f.get("title") or "").strip().lower())
+    key = f"{f.get('file','')}|{f.get('bug_class','')}|{title}"
+    return hashlib.sha1(key.encode()).hexdigest()[:16]
+
+
+def load_manifest(work_dir):
+    with open(os.path.join(work_dir, "manifest.json")) as f:
+        return json.load(f)
+
+
+def load_cache(path):
+    try:
+        with open(path) as f:
+            return json.load(f)
+    except Exception:
+        return {"lastScanSha": None, "lastScanAt": None, "seen": {}}
+
+
+def save_cache(path, cache):
+    os.makedirs(os.path.dirname(path), exist_ok=True)
+    with open(path, "w") as f:
+        json.dump(cache, f, indent=2)
+
+
+def open_issue_titles():
+    """Titles of currently-open ai-generated issues, for cross-run dedup."""
+    try:
+        out = subprocess.run(
+            ["gh", "issue", "list", "--repo", ISSUE_REPO, "--label", AI_LABEL,
+             "--state", "open", "--limit", "200", "--json", "title"],
+            capture_output=True, text=True, timeout=60,
+        )
+        if out.returncode == 0:
+            return {re.sub(r"\s+", " ", i["title"].strip().lower())
+                    for i in json.loads(out.stdout or "[]")}
+    except Exception:
+        pass
+    return set()
+
+
+def collect_results(manifest):
+    findings = []
+    for chunk in manifest["chunks"]:
+        rf = chunk["results_file"]
+        if not os.path.exists(rf):
+            log(f"discover-bugs: no result file for {chunk['chunk_id']} (subagent skipped?)")
+            continue
+        try:
+            with open(rf) as f:
+                data = json.load(f)
+            for item in data.get("findings", []):
+                findings.append(item)
+        except Exception as e:
+            log(f"discover-bugs: bad result file {rf}: {e}")
+    return findings
+
+
+def issue_body(f, head_sha):
+    return f"""**Automated bug scan finding — please confirm before acting.**
+
+This issue was filed by an automated static scan (label `{AI_LABEL}`). It has
+not been human-verified. If it is a false positive, close it.
+
+- **File:** `{f.get('file')}:{f.get('line')}`
+- **Class:** {f.get('bug_class')}
+- **Severity:** {f.get('severity')}  |  **Scanner confidence:** {f.get('confidence')}
+- **Scanned commit:** `{(head_sha or '')[:12]}`
+
+**What goes wrong**
+{f.get('description','(none)')}
+
+**Suggested direction**
+{f.get('suggested_fix','(none)')}
+"""
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--work-dir", required=True)
+    ap.add_argument("--file-issues", action="store_true",
+                    help="Create GitHub issues (default: local report only).")
+    args = ap.parse_args()
+
+    manifest = load_manifest(args.work_dir)
+    cache_path = manifest["cache_path"]
+    head_sha = manifest.get("head_sha")
+    cache = load_cache(cache_path)
+    seen = cache.setdefault("seen", {})
+
+    raw = collect_results(manifest)
+
+    # Confidence gate: v1 keeps only high-confidence.
+    gated = [f for f in raw if (f.get("confidence") or "").lower() == "high"]
+    dropped_conf = len(raw) - len(gated)
+
+    # Dedup against local seen-list and open ai-generated issues.
+    existing_titles = open_issue_titles()
+    fresh, dup = [], 0
+    for f in gated:
+        fp = fingerprint(f)
+        title_norm = re.sub(r"\s+", " ", (f.get("title") or "").strip().lower())
+        if fp in seen or title_norm in existing_titles:
+            dup += 1
+            continue
+        f["_fp"] = fp
+        fresh.append(f)
+
+    log(f"discover-bugs: {len(raw)} raw finding(s); "
+        f"{dropped_conf} below high-confidence; {dup} duplicate(s); "
+        f"{len(fresh)} fresh.")
+
+    now = datetime.now(timezone.utc).isoformat()
+    filed = []
+
+    if args.file_issues:
+        for f in fresh:
+            title = f"[ai-bug] {f.get('title')}"
+            body = issue_body(f, head_sha)
+            try:
+                out = subprocess.run(
+                    ["gh", "issue", "create", "--repo", ISSUE_REPO,
+                     "--label", AI_LABEL, "--title", title, "--body", body],
+                    capture_output=True, text=True, timeout=90,
+                )
+                if out.returncode == 0:
+                    url = out.stdout.strip()
+                    seen[f["_fp"]] = {"issue": url, "reportedAt": now}
+                    filed.append(url)
+                    log(f"discover-bugs: filed {url}")
+                else:
+                    log(f"discover-bugs: gh issue create failed: {out.stderr.strip()}")
+            except Exception as e:
+                log(f"discover-bugs: gh issue create error: {e}")
+    else:
+        # Local report only. Record fresh findings in seen so we don't re-report
+        # them next run even before issues are filed.
+        for f in fresh:
+            seen[f["_fp"]] = {"issue": None, "reportedAt": now}
+
+    # Always write a local report artifact.
+    os.makedirs(LOGS_DIR, exist_ok=True)
+    stamp = now.replace(":", "").replace("-", "")[:15]
+    report_json = os.path.join(LOGS_DIR, f"discover-bugs-{stamp}.json")
+    with open(report_json, "w") as f:
+        json.dump({"scanned_at": now, "head_sha": head_sha,
+                   "fresh": fresh, "filed": filed,
+                   "counts": {"raw": len(raw), "dropped_conf": dropped_conf,
+                              "duplicate": dup, "fresh": len(fresh)}},
+                  f, indent=2)
+
+    report_md = os.path.join(LOGS_DIR, f"discover-bugs-{stamp}.md")
+    with open(report_md, "w") as fh:
+        fh.write(f"# Bug scan — {now}\n\nBase: {manifest.get('base_desc')}  |  "
+                 f"Commit: {(head_sha or '')[:12]}\n\n")
+        if not fresh:
+            fh.write("No fresh high-confidence findings.\n")
+        for f in fresh:
+            link = f" — {seen[f['_fp']]['issue']}" if seen.get(f["_fp"], {}).get("issue") else ""
+            fh.write(f"## {f.get('title')}{link}\n"
+                     f"- `{f.get('file')}:{f.get('line')}` · {f.get('bug_class')} · "
+                     f"sev {f.get('severity')}\n- {f.get('description')}\n"
+                     f"- Fix: {f.get('suggested_fix')}\n\n")
+
+    # Update cache marker so the next scan starts from here.
+    if head_sha:
+        cache["lastScanSha"] = head_sha
+    cache["lastScanAt"] = now
+    save_cache(cache_path, cache)
+
+    mode = "filed as issues" if args.file_issues else "LOCAL REPORT ONLY (no issues filed)"
+    log("=" * 60)
+    log(f"discover-bugs summary — {mode}")
+    log(f"  fresh high-confidence: {len(fresh)}")
+    if args.file_issues:
+        log(f"  issues created: {len(filed)}")
+    log(f"  report: {report_md}")
+    log("=" * 60)
+
+
+if __name__ == "__main__":
+    main()

--- a/.claude/skills/discover-bugs/collect-findings.py
+++ b/.claude/skills/discover-bugs/collect-findings.py
@@ -3,14 +3,15 @@
 
 Zero-LLM. Reads all subagent result files, applies the confidence gate,
 deduplicates against previously-reported findings and open ai-generated
-issues, then EITHER writes a local report (default) OR files GitHub issues
-labeled `ai-generated` (--file-issues). Updates the scan cache either way.
+issues, PRIORITIZES survivors (P0/P1/P2), then EITHER writes a local report
+OR files GitHub issues labeled `ai-generated`. Updates the scan cache.
+
+In POD MODE it also advances the per-pod scan state: during a baseline sweep
+it moves the cursor forward (and flips the pod to changed-only once the sweep
+is complete); in changed-only mode it records the new base commit.
 
 Usage:
     python3 collect-findings.py --work-dir DIR [--file-issues]
-
-Default is local-report-only: NO external writes until a human has reviewed
-the scanner's false-positive rate. --file-issues flips on issue creation.
 """
 
 import argparse
@@ -18,10 +19,11 @@ import hashlib
 import json
 import os
 import re
-import subprocess
+# subprocess is used only to invoke `git` and `gh` with fixed, list-form argv
+# (never shell=True, never a shell string), so there is no shell-injection surface.
+import subprocess  # nosemgrep: gitlab.bandit.B404
 import sys
 from datetime import datetime, timezone
-from pathlib import Path
 
 _SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
 _BOT_DIR = os.path.normpath(os.path.join(_SCRIPT_DIR, "..", "..", ".."))
@@ -34,16 +36,35 @@ ISSUE_REPO = require_config(_config, "project.issueRepository")
 AI_LABEL = "ai-generated"
 LOGS_DIR = os.path.join(_BOT_DIR, "logs")
 
+_SEV_W = {"critical": 4, "high": 3, "medium": 2, "low": 1}
+_HOT_CLASSES = {"security", "crypto", "mojo-ipc", "lifetime-uaf", "bounds",
+                "integer-over-underflow", "stack-overflow"}
+
 
 def log(msg):
     print(msg, file=sys.stderr)
 
 
 def fingerprint(f):
-    """Stable id for a finding: file + class + normalized title."""
+    """Stable dedup id for a finding: file + class + normalized title.
+
+    Non-cryptographic — this is a content-addressed key for deduping findings,
+    not a signature. SHA-256 (truncated) purely to satisfy static scanners.
+    """
     title = re.sub(r"\s+", " ", (f.get("title") or "").strip().lower())
     key = f"{f.get('file','')}|{f.get('bug_class','')}|{title}"
-    return hashlib.sha1(key.encode()).hexdigest()[:16]
+    return hashlib.sha256(key.encode()).hexdigest()[:16]
+
+
+def prioritize(f):
+    """Attach _score (int) and _tier (P0/P1/P2) to a finding."""
+    sev = (f.get("severity") or "medium").lower()
+    cls = (f.get("bug_class") or "").lower()
+    score = _SEV_W.get(sev, 2) + (1 if cls in _HOT_CLASSES else 0)
+    tier = "P0" if score >= 5 else ("P1" if score >= 3 else "P2")
+    f["_score"] = score
+    f["_tier"] = tier
+    return f
 
 
 def load_manifest(work_dir):
@@ -70,7 +91,7 @@ def open_issue_titles():
     try:
         out = subprocess.run(
             ["gh", "issue", "list", "--repo", ISSUE_REPO, "--label", AI_LABEL,
-             "--state", "open", "--limit", "200", "--json", "title"],
+             "--state", "open", "--limit", "300", "--json", "title"],
             capture_output=True, text=True, timeout=60,
         )
         if out.returncode == 0:
@@ -98,13 +119,15 @@ def collect_results(manifest):
     return findings
 
 
-def issue_body(f, head_sha):
+def issue_body(f, head_sha, pod_label):
+    pod_line = f"- **Pod:** {pod_label}\n" if pod_label else ""
     return f"""**Automated bug scan finding — please confirm before acting.**
 
 This issue was filed by an automated static scan (label `{AI_LABEL}`). It has
 not been human-verified. If it is a false positive, close it.
 
-- **File:** `{f.get('file')}:{f.get('line')}`
+- **Priority:** {f.get('_tier')} (score {f.get('_score')})
+{pod_line}- **File:** `{f.get('file')}:{f.get('line')}`
 - **Class:** {f.get('bug_class')}
 - **Severity:** {f.get('severity')}  |  **Scanner confidence:** {f.get('confidence')}
 - **Scanned commit:** `{(head_sha or '')[:12]}`
@@ -117,6 +140,23 @@ not been human-verified. If it is a false positive, close it.
 """
 
 
+def update_pod_cache(cache, manifest, head_sha, now):
+    """Advance the per-pod full-sweep cursor; on completion, reset for the next
+    cycle and stamp the cooldown clock. Full-codebase model — no changed-only."""
+    if manifest.get("cycle_complete_after"):
+        # Whole tree swept this cycle. Reset the cursor so the next cycle starts
+        # from the top, and record when we finished so the cooldown can elapse.
+        cache["cycleComplete"] = True
+        cache["cycleCompletedAt"] = now
+        cache["cycleCompletedSha"] = head_sha
+        cache["sweepCursor"] = ""
+    else:
+        # Mid-sweep: advance the cursor to the last file scanned this run.
+        cache["sweepCursor"] = manifest.get("batch_last_path") or cache.get("sweepCursor", "")
+        cache["cycleComplete"] = False
+    cache["lastScanAt"] = now
+
+
 def main():
     ap = argparse.ArgumentParser()
     ap.add_argument("--work-dir", required=True)
@@ -125,6 +165,9 @@ def main():
     args = ap.parse_args()
 
     manifest = load_manifest(args.work_dir)
+    is_pod = manifest.get("mode") == "pod"
+    pod_id = manifest.get("pod_id")
+    pod_label = manifest.get("pod_label")
     cache_path = manifest["cache_path"]
     head_sha = manifest.get("head_sha")
     cache = load_cache(cache_path)
@@ -132,7 +175,7 @@ def main():
 
     raw = collect_results(manifest)
 
-    # Confidence gate: v1 keeps only high-confidence.
+    # Confidence gate: keep only high-confidence.
     gated = [f for f in raw if (f.get("confidence") or "").lower() == "high"]
     dropped_conf = len(raw) - len(gated)
 
@@ -146,9 +189,15 @@ def main():
             dup += 1
             continue
         f["_fp"] = fp
+        prioritize(f)
         fresh.append(f)
 
-    log(f"discover-bugs: {len(raw)} raw finding(s); "
+    # Highest priority first.
+    fresh.sort(key=lambda f: (f["_score"], _SEV_W.get((f.get("severity") or "").lower(), 0)),
+               reverse=True)
+
+    tag = f"[{pod_id}]" if is_pod else ""
+    log(f"discover-bugs{tag}: {len(raw)} raw finding(s); "
         f"{dropped_conf} below high-confidence; {dup} duplicate(s); "
         f"{len(fresh)} fresh.")
 
@@ -157,8 +206,9 @@ def main():
 
     if args.file_issues:
         for f in fresh:
-            title = f"[ai-bug] {f.get('title')}"
-            body = issue_body(f, head_sha)
+            pod_prefix = f"[{pod_id}]" if is_pod else ""
+            title = f"[ai-bug][{f['_tier']}]{pod_prefix} {f.get('title')}"
+            body = issue_body(f, head_sha, pod_label)
             try:
                 out = subprocess.run(
                     ["gh", "issue", "create", "--repo", ISSUE_REPO,
@@ -167,53 +217,67 @@ def main():
                 )
                 if out.returncode == 0:
                     url = out.stdout.strip()
-                    seen[f["_fp"]] = {"issue": url, "reportedAt": now}
+                    seen[f["_fp"]] = {"issue": url, "reportedAt": now, "tier": f["_tier"]}
                     filed.append(url)
-                    log(f"discover-bugs: filed {url}")
+                    log(f"discover-bugs{tag}: filed {f['_tier']} {url}")
                 else:
-                    log(f"discover-bugs: gh issue create failed: {out.stderr.strip()}")
+                    log(f"discover-bugs{tag}: gh issue create failed: {out.stderr.strip()}")
             except Exception as e:
-                log(f"discover-bugs: gh issue create error: {e}")
+                log(f"discover-bugs{tag}: gh issue create error: {e}")
     else:
-        # Local report only. Record fresh findings in seen so we don't re-report
-        # them next run even before issues are filed.
         for f in fresh:
-            seen[f["_fp"]] = {"issue": None, "reportedAt": now}
+            seen[f["_fp"]] = {"issue": None, "reportedAt": now, "tier": f["_tier"]}
 
-    # Always write a local report artifact.
+    # Local report artifact.
     os.makedirs(LOGS_DIR, exist_ok=True)
     stamp = now.replace(":", "").replace("-", "")[:15]
-    report_json = os.path.join(LOGS_DIR, f"discover-bugs-{stamp}.json")
-    with open(report_json, "w") as f:
-        json.dump({"scanned_at": now, "head_sha": head_sha,
-                   "fresh": fresh, "filed": filed,
+    slug = f"-{pod_id}" if is_pod else ""
+    report_json = os.path.join(LOGS_DIR, f"discover-bugs{slug}-{stamp}.json")
+    with open(report_json, "w") as fj:
+        json.dump({"scanned_at": now, "pod": pod_id, "scan_mode": manifest.get("scan_mode"),
+                   "head_sha": head_sha, "fresh": fresh, "filed": filed,
                    "counts": {"raw": len(raw), "dropped_conf": dropped_conf,
                               "duplicate": dup, "fresh": len(fresh)}},
-                  f, indent=2)
+                  fj, indent=2)
 
-    report_md = os.path.join(LOGS_DIR, f"discover-bugs-{stamp}.md")
+    report_md = os.path.join(LOGS_DIR, f"discover-bugs{slug}-{stamp}.md")
     with open(report_md, "w") as fh:
-        fh.write(f"# Bug scan — {now}\n\nBase: {manifest.get('base_desc')}  |  "
+        area = f"{pod_label} (`{pod_id}`)" if is_pod else "repo-wide"
+        fh.write(f"# Bug scan — {area} — {now}\n\n"
+                 f"Mode: {manifest.get('scan_mode', manifest.get('base_desc'))}  |  "
+                 f"Base: {manifest.get('base_desc')}  |  "
                  f"Commit: {(head_sha or '')[:12]}\n\n")
         if not fresh:
             fh.write("No fresh high-confidence findings.\n")
         for f in fresh:
             link = f" — {seen[f['_fp']]['issue']}" if seen.get(f["_fp"], {}).get("issue") else ""
-            fh.write(f"## {f.get('title')}{link}\n"
+            fh.write(f"## {f['_tier']} · {f.get('title')}{link}\n"
                      f"- `{f.get('file')}:{f.get('line')}` · {f.get('bug_class')} · "
-                     f"sev {f.get('severity')}\n- {f.get('description')}\n"
+                     f"sev {f.get('severity')} · score {f['_score']}\n"
+                     f"- {f.get('description')}\n"
                      f"- Fix: {f.get('suggested_fix')}\n\n")
 
-    # Update cache marker so the next scan starts from here.
-    if head_sha:
-        cache["lastScanSha"] = head_sha
-    cache["lastScanAt"] = now
+    # Update scan state.
+    if is_pod:
+        update_pod_cache(cache, manifest, head_sha, now)
+    else:
+        if head_sha:
+            cache["lastScanSha"] = head_sha
+        cache["lastScanAt"] = now
     save_cache(cache_path, cache)
 
     mode = "filed as issues" if args.file_issues else "LOCAL REPORT ONLY (no issues filed)"
+    tiers = {}
+    for f in fresh:
+        tiers[f["_tier"]] = tiers.get(f["_tier"], 0) + 1
     log("=" * 60)
-    log(f"discover-bugs summary — {mode}")
-    log(f"  fresh high-confidence: {len(fresh)}")
+    log(f"discover-bugs{tag} summary — {mode}")
+    log(f"  fresh high-confidence: {len(fresh)}  "
+        f"(P0={tiers.get('P0',0)} P1={tiers.get('P1',0)} P2={tiers.get('P2',0)})")
+    if is_pod:
+        log(f"  pod scan_mode: {manifest.get('scan_mode')}"
+            + ("  [full sweep COMPLETE — pod idles until next re-scan cycle]"
+               if manifest.get("cycle_complete_after") else ""))
     if args.file_issues:
         log(f"  issues created: {len(filed)}")
     log(f"  report: {report_md}")

--- a/.claude/skills/discover-bugs/pods.json
+++ b/.claude/skills/discover-bugs/pods.json
@@ -1,0 +1,140 @@
+{
+  "_comment": "Machine source of truth for the per-pod bug scan. Each entry is ONE scan task (its own cron job + its own subagent). 'paths' and 'exclude' are fnmatch globs matched against repo-relative paths in the target repo (brave-core); note '*' matches '/' too, so 'components/foo/*' matches nested files. Regenerate PODS.md after editing: python3 prepare-scan.py --sync-doc. Verified against brave-browser/src/brave on master.",
+  "target_branch": "master",
+  "pods": [
+    {
+      "id": "ai-chat",
+      "label": "AI Chat / Leo",
+      "paths": ["components/ai_chat/*", "browser/ai_chat/*"],
+      "focus": "Conversation state lifetime, streaming response handling, untrusted model/server output parsing, tab-content extraction, feature-flag gating."
+    },
+    {
+      "id": "wallet-ethereum",
+      "label": "Wallet — Ethereum/EVM",
+      "paths": ["components/brave_wallet/browser/eth_*", "components/brave_wallet/browser/eip*", "components/brave_wallet/browser/ethereum_*"],
+      "focus": "EVM tx construction/signing, ABI decode bounds, nonce/gas math integer over/underflow, RPC response parsing, allowance handling."
+    },
+    {
+      "id": "wallet-solana",
+      "label": "Wallet — Solana",
+      "paths": ["components/brave_wallet/browser/solana*"],
+      "focus": "Instruction/message compilation bounds, account-meta indexing, signature/serialization correctness, untrusted RPC parsing."
+    },
+    {
+      "id": "wallet-bitcoin",
+      "label": "Wallet — Bitcoin",
+      "paths": ["components/brave_wallet/browser/bitcoin/*"],
+      "focus": "UTXO selection/amount math over/underflow, PSBT/tx serialization bounds, key derivation, block-tracker lifetime."
+    },
+    {
+      "id": "wallet-zcash",
+      "label": "Wallet — Zcash",
+      "paths": ["components/brave_wallet/browser/zcash/*"],
+      "focus": "Shielded/transparent tx math, orchard/librustzcash FFI boundary validation, serialization bounds, amount over/underflow."
+    },
+    {
+      "id": "wallet-other-chains",
+      "label": "Wallet — Cardano/Polkadot/Filecoin/internal",
+      "paths": ["components/brave_wallet/browser/cardano/*", "components/brave_wallet/browser/polkadot/*", "components/brave_wallet/browser/internal/*", "components/brave_wallet/browser/filecoin_*", "components/brave_wallet/browser/fil_*"],
+      "focus": "Chain-specific tx/amount math, serialization bounds, FFI/internal boundary validation, key handling."
+    },
+    {
+      "id": "wallet-keyring",
+      "label": "Wallet — Keyring / key management",
+      "paths": ["components/brave_wallet/browser/*keyring*"],
+      "focus": "Seed/private-key lifetime and zeroing, mnemonic handling, keyring migration correctness, unlock/lock state, password handling."
+    },
+    {
+      "id": "wallet-core",
+      "label": "Wallet — Core services & UI",
+      "paths": ["components/brave_wallet/*", "components/brave_wallet_ui/*", "browser/brave_wallet/*"],
+      "exclude": ["components/brave_wallet/browser/eth_*", "components/brave_wallet/browser/eip*", "components/brave_wallet/browser/ethereum_*", "components/brave_wallet/browser/solana*", "components/brave_wallet/browser/bitcoin/*", "components/brave_wallet/browser/zcash/*", "components/brave_wallet/browser/cardano/*", "components/brave_wallet/browser/polkadot/*", "components/brave_wallet/browser/internal/*", "components/brave_wallet/browser/filecoin_*", "components/brave_wallet/browser/fil_*", "components/brave_wallet/browser/*keyring*"],
+      "focus": "Service/factory object lifetime, mojo/IPC validation of renderer-supplied values, asset/price parsing, permission checks, WeakPtr use-after-invalidate."
+    },
+    {
+      "id": "shields",
+      "label": "Shields (content settings, blocking core)",
+      "paths": ["components/brave_shields/*", "browser/brave_shields/*"],
+      "exclude": ["components/brave_shields/core/browser/ad_block_*", "components/brave_shields/core/browser/adblock*", "components/brave_shields/*farbl*", "components/brave_shields/*fingerprint*"],
+      "focus": "Content-settings resolution correctness, per-site rule application, cross-thread access to shields state, null pref/host-content-settings reads."
+    },
+    {
+      "id": "adblock",
+      "label": "Adblock component",
+      "paths": ["components/brave_shields/core/browser/ad_block_*", "components/brave_shields/core/browser/adblock*", "components/brave_adblock_ui/*", "components/brave_shields/content/*ad_block*"],
+      "focus": "Filter-list provider lifetime, component/DAT loading and parsing bounds, engine update races, untrusted rule/resource parsing."
+    },
+    {
+      "id": "fingerprinting",
+      "label": "Fingerprinting protection (farbling)",
+      "paths": ["components/script_injector/*", "components/brave_shields/*farbl*", "components/brave_shields/*fingerprint*"],
+      "focus": "Farbling seed derivation, script injection into untrusted frames, per-origin randomization consistency, renderer-side value validation."
+    },
+    {
+      "id": "sync",
+      "label": "Sync",
+      "paths": ["components/brave_sync/*", "components/sync/*", "components/sync_device_info/*", "components/sync_preferences/*", "browser/sync/*"],
+      "focus": "Sync record encode/decode of untrusted server data, crypto/nudge handling, device-info lifetime, cross-sequence access, migration correctness."
+    },
+    {
+      "id": "vpn",
+      "label": "VPN",
+      "paths": ["components/brave_vpn/*", "browser/brave_vpn/*"],
+      "focus": "Connection state machine correctness, credential/subscription handling, region-list parsing of server data, connection-observer lifetime."
+    },
+    {
+      "id": "talk",
+      "label": "Talk",
+      "paths": ["components/brave_talk/*", "components/brave_new_tab_ui/components/default/braveTalk/*", "ios/browser/brave_talk/*"],
+      "focus": "Talk integration/launch flow, message-handler input validation, native-JS bridge value validation."
+    },
+    {
+      "id": "talk-premium",
+      "label": "Talk Premium / SKUs entitlement",
+      "paths": ["components/skus/*", "browser/skus/*"],
+      "focus": "SKU/entitlement verification that gates Talk & VPN premium, credential/order-state parsing of server responses, expiry math, replay/forgery of entitlement state."
+    },
+    {
+      "id": "news",
+      "label": "News",
+      "paths": ["components/brave_news/*", "browser/brave_news/*"],
+      "focus": "Feed/publisher parsing of untrusted network data, image/URL handling, feed-controller lifetime, cross-thread feed updates."
+    },
+    {
+      "id": "sidebar",
+      "label": "Sidebar",
+      "paths": ["components/sidebar/*", "browser/ui/sidebar/*"],
+      "focus": "Sidebar item model lifetime vs UI, tab/browser observer teardown, null browser/webcontents reads, item ordering correctness."
+    },
+    {
+      "id": "speedreader",
+      "label": "Speedreader",
+      "paths": ["components/speedreader/*", "browser/speedreader/*"],
+      "focus": "Distillation of untrusted page content, throttle/delegate lifetime, renderer boundary validation, null document reads."
+    },
+    {
+      "id": "tor",
+      "label": "Tor",
+      "paths": ["components/tor/*", "browser/tor/*"],
+      "focus": "Tor process/launcher lifetime, control-port parsing, proxy config correctness, profile teardown, leaking identifiers across sessions."
+    },
+    {
+      "id": "wayback-machine",
+      "label": "Wayback Machine",
+      "paths": ["components/brave_wayback_machine/*"],
+      "focus": "Wayback API response parsing, infobar/delegate lifetime vs webcontents, null response handling, URL validation."
+    },
+    {
+      "id": "web-discovery",
+      "label": "Web Discovery",
+      "paths": ["components/web_discovery/*", "browser/web_discovery/*"],
+      "focus": "Untrusted page/content extraction and reporting, anonymization/hashing correctness, scheduler/observer lifetime, PII leakage in payloads."
+    },
+    {
+      "id": "email-aliases",
+      "label": "Email Aliases",
+      "paths": ["components/email_aliases/*", "browser/email_aliases/*"],
+      "focus": "Alias service state, server-response parsing, auth/session handling, mojo/IPC validation, alias-list lifetime."
+    }
+  ]
+}

--- a/.claude/skills/discover-bugs/prepare-scan.py
+++ b/.claude/skills/discover-bugs/prepare-scan.py
@@ -1,0 +1,269 @@
+#!/usr/bin/env python3
+"""Phase 1 pre-work for the discover-bugs skill.
+
+Zero-LLM candidate selection for a bounded static bug scan of the target
+repository. Selects source files that changed since the last scan (or over a
+recent window), writes one subagent prompt file per chunk, and emits a small
+manifest. The main LLM session only orchestrates — it never sees file contents.
+
+Usage:
+    python3 prepare-scan.py [--since-cache | --commits N | --days N]
+                            [--max-files N] [--files-per-chunk N] [--auto]
+
+Selection precedence (highest first):
+    --commits N      diff HEAD~N..HEAD
+    --days N         files touched by commits in the last N days
+    --since-cache    diff <lastScanSha>..HEAD   (default; falls back to --days 7)
+"""
+
+import argparse
+import hashlib
+import json
+import os
+import subprocess
+import sys
+import tempfile
+from datetime import datetime, timezone
+from pathlib import Path
+
+_SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
+_BOT_DIR = os.path.normpath(os.path.join(_SCRIPT_DIR, "..", "..", ".."))
+sys.path.insert(0, os.path.join(_BOT_DIR, "scripts"))
+
+from lib.load_config import load_config, require_config, get_config
+
+# --- config -----------------------------------------------------------------
+_config = load_config()
+ISSUE_REPO = require_config(_config, "project.issueRepository")
+
+
+def _resolve_target(rel):
+    """Match run.sh: absolute paths as-is, else relative to the bot dir's parent."""
+    if os.path.isabs(rel):
+        return os.path.normpath(rel)
+    return os.path.normpath(os.path.join(_BOT_DIR, "..", rel))
+
+
+TARGET_REPO_PATH = _resolve_target(require_config(_config, "project.targetRepoPath"))
+CACHE_PATH = os.path.join(_BOT_DIR, ".ignore", "discover-bugs-cache.json")
+
+# Source extensions worth scanning for logic/lifetime bugs.
+SOURCE_EXTS = {".cc", ".cpp", ".cxx", ".mm", ".m", ".h", ".hpp", ".ts", ".tsx", ".js"}
+# Paths/patterns to skip — tests and generated/vendored trees are low signal.
+SKIP_SUBSTR = ("/test/", "/tests/", "/third_party/", "/node_modules/", "/gen/")
+SKIP_SUFFIX = ("_unittest.cc", "_browsertest.cc", "_unittest.mm", ".test.ts", ".test.tsx")
+
+DEFAULT_MAX_FILES = 40
+DEFAULT_FILES_PER_CHUNK = 5
+
+# Bug-class rubric handed to every subagent. Focused on the classes that
+# actually recur in Brave/Chromium C++ (the US-005 UAF was class #1).
+RUBRIC = """\
+Scan ONLY for high-confidence, concrete defects in the classes below. Do NOT
+report style, naming, or subjective design preferences.
+
+1. Lifetime / use-after-free: dangling `raw_ptr`/`raw_ref`, pointers outliving
+   their owner, missing `RegisterWillDetach`/unsubscribe on teardown, capturing
+   `this`/refs in callbacks that outlive the object, iterator invalidation.
+2. Threading / sequence: cross-sequence access without posting, missing
+   `SEQUENCE_CHECKER`, data races on shared state, blocking the UI thread.
+3. Null / bounds: unchecked deref of a pointer that can be null (`GetFoo()`
+   returning null, `WeakPtr` used after invalidation), off-by-one / OOB index.
+4. Mojo / IPC: trusting a renderer-supplied value without validation, missing
+   `mojo::ReportBadMessage`, lifetime of self-owned receivers.
+5. Uninitialized / resource: uninitialized member read, leaked handle/fd,
+   missing `Close()`/`Release()` on an error path.
+
+For each finding you MUST be able to point to the exact line and explain the
+concrete failure (what input/state triggers it, what goes wrong). If you are
+not confident it is a real bug, DROP it — false positives are worse than misses.
+"""
+
+
+def log(msg):
+    print(msg, file=sys.stderr)
+
+
+def git(*args):
+    """Read-only git in the target repo. Returns stdout (stripped) or ''."""
+    try:
+        out = subprocess.run(
+            ["git", "-C", TARGET_REPO_PATH, *args],
+            capture_output=True, text=True, timeout=120,
+        )
+        return out.stdout.strip() if out.returncode == 0 else ""
+    except Exception:
+        return ""
+
+
+def load_cache():
+    try:
+        with open(CACHE_PATH) as f:
+            return json.load(f)
+    except Exception:
+        return {"lastScanSha": None, "lastScanAt": None, "seen": {}}
+
+
+def is_scannable(path):
+    p = path.lower()
+    if Path(path).suffix.lower() not in SOURCE_EXTS:
+        return False
+    if any(s in p for s in SKIP_SUBSTR):
+        return False
+    if any(p.endswith(s) for s in SKIP_SUFFIX):
+        return False
+    return True
+
+
+def resolve_base(args, cache):
+    """Return (base_ref, description). base_ref is a git ref or None (window)."""
+    if args.commits:
+        return f"HEAD~{args.commits}", f"last {args.commits} commits"
+    if args.days:
+        return None, f"last {args.days} days"
+    # --since-cache (default)
+    sha = cache.get("lastScanSha")
+    if sha and git("rev-parse", "--verify", "--quiet", sha + "^{commit}"):
+        return sha, f"since last scan ({sha[:12]})"
+    log("No valid last-scan marker — falling back to last 7 days.")
+    args.days = 7
+    return None, "last 7 days (no cache)"
+
+
+def changed_files(base_ref, days):
+    if base_ref:
+        raw = git("diff", "--name-only", f"{base_ref}..HEAD")
+    else:
+        # files touched by commits within the window
+        raw = git("log", f"--since={days} days ago", "--name-only",
+                  "--pretty=format:", "HEAD")
+    files = sorted({ln.strip() for ln in raw.splitlines() if ln.strip()})
+    return [f for f in files if is_scannable(f)]
+
+
+def file_diff(base_ref, path):
+    """Diff for a changed file (bounded); full file if newly added / no base."""
+    if base_ref:
+        d = git("diff", f"{base_ref}..HEAD", "--", path)
+        if d:
+            return d
+    # new file or window mode — show current content with line numbers
+    full = os.path.join(TARGET_REPO_PATH, path)
+    try:
+        with open(full, encoding="utf-8", errors="replace") as f:
+            lines = f.read().splitlines()
+        return "\n".join(f"{i+1:>5}\t{ln}" for i, ln in enumerate(lines[:1200]))
+    except Exception:
+        return ""
+
+
+def build_prompt(chunk_files, base_ref, results_file):
+    parts = [
+        "You are a C++/TypeScript bug-finding subagent scanning Brave (a Chromium "
+        "fork) source for concrete defects.\n",
+        RUBRIC,
+        "\n--- FILES TO SCAN (unified diffs; scan the changed/new code) ---\n",
+    ]
+    for path in chunk_files:
+        parts.append(f"\n### {path}\n```\n{file_diff(base_ref, path)}\n```\n")
+    parts.append(f"""
+--- OUTPUT ---
+Read the actual source files under {TARGET_REPO_PATH} as needed to CONFIRM each
+finding before reporting it. Then write a JSON file to EXACTLY this path:
+
+  {results_file}
+
+Schema:
+{{
+  "findings": [
+    {{
+      "file": "<repo-relative path>",
+      "line": <int>,
+      "bug_class": "lifetime|threading|null-bounds|mojo-ipc|uninitialized",
+      "severity": "low|medium|high",
+      "confidence": "low|medium|high",
+      "title": "<one line>",
+      "description": "<what input/state triggers it and what goes wrong>",
+      "suggested_fix": "<concrete direction>"
+    }}
+  ]
+}}
+
+Report ONLY confidence:high findings. If you find nothing solid, write
+{{"findings": []}}. Do not invent bugs to fill the list.
+""")
+    return "".join(parts)
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    g = ap.add_mutually_exclusive_group()
+    g.add_argument("--since-cache", action="store_true")
+    g.add_argument("--commits", type=int)
+    g.add_argument("--days", type=int)
+    ap.add_argument("--max-files", type=int, default=DEFAULT_MAX_FILES)
+    ap.add_argument("--files-per-chunk", type=int, default=DEFAULT_FILES_PER_CHUNK)
+    ap.add_argument("--auto", action="store_true")
+    args = ap.parse_args()
+
+    if not os.path.isdir(os.path.join(TARGET_REPO_PATH, ".git")):
+        log(f"Error: target repo not found at {TARGET_REPO_PATH}")
+        sys.exit(1)
+
+    cache = load_cache()
+    base_ref, base_desc = resolve_base(args, cache)
+    head_sha = git("rev-parse", "HEAD")
+
+    files = changed_files(base_ref, args.days)
+    total_found = len(files)
+    capped = False
+    if len(files) > args.max_files:
+        files = files[: args.max_files]
+        capped = True
+
+    work_dir = tempfile.mkdtemp(prefix="discover-bugs-")
+    chunks = []
+    for i in range(0, len(files), args.files_per_chunk):
+        chunk_files = files[i : i + args.files_per_chunk]
+        cid = f"chunk_{i // args.files_per_chunk}"
+        prompt_file = os.path.join(work_dir, f"{cid}_prompt.txt")
+        results_file = os.path.join(work_dir, f"{cid}_results.json")
+        with open(prompt_file, "w") as f:
+            f.write(build_prompt(chunk_files, base_ref, results_file))
+        chunks.append({"chunk_id": cid, "files": chunk_files,
+                       "prompt_file": prompt_file, "results_file": results_file})
+
+    progress = [f"discover-bugs: base = {base_desc}",
+                f"discover-bugs: {total_found} scannable file(s) changed"
+                + (f", capped to {args.max_files}" if capped else "")
+                + f" -> {len(chunks)} chunk(s)"]
+    if capped:
+        progress.append(f"discover-bugs: WARNING — {total_found - args.max_files} "
+                        f"changed file(s) NOT scanned this run (raise --max-files).")
+    for line in progress:
+        log(line)
+
+    manifest = {
+        "work_dir": work_dir,
+        "auto_mode": args.auto,
+        "issue_repo": ISSUE_REPO,
+        "target_repo_path": TARGET_REPO_PATH,
+        "base_ref": base_ref,
+        "base_desc": base_desc,
+        "head_sha": head_sha,
+        "cache_path": CACHE_PATH,
+        "seen_count": len(cache.get("seen", {})),
+        "total_changed": total_found,
+        "capped": capped,
+        "chunks": chunks,
+        "progress_lines": progress,
+    }
+    manifest_path = os.path.join(work_dir, "manifest.json")
+    with open(manifest_path, "w") as f:
+        json.dump(manifest, f, indent=2)
+
+    print(json.dumps({"work_dir": work_dir, "manifest": manifest_path}))
+
+
+if __name__ == "__main__":
+    main()

--- a/.claude/skills/discover-bugs/prepare-scan.py
+++ b/.claude/skills/discover-bugs/prepare-scan.py
@@ -2,25 +2,36 @@
 """Phase 1 pre-work for the discover-bugs skill.
 
 Zero-LLM candidate selection for a bounded static bug scan of the target
-repository. Selects source files that changed since the last scan (or over a
-recent window), writes one subagent prompt file per chunk, and emits a small
-manifest. The main LLM session only orchestrates — it never sees file contents.
+repository. The main LLM session only orchestrates — it never sees file
+contents; everything heavy goes through files.
+
+Two selection modes:
+
+  * POD MODE (--pod <id>): scan ONE product/pod from pods.json. Each pod runs
+    as its own cron job / subagent. Full-codebase model — the pod's ENTIRE tree
+    on master is scanned as full source (never diffs), swept in bounded slices
+    that rotate across runs via a cursor in the per-pod cache. When a full sweep
+    completes the pod idles for a cooldown (--rescan-days / per-pod
+    'rescan_interval_days'), then sweeps the whole tree again. There is no
+    changed-only phase: the whole codebase is re-audited every cycle.
+
+  * LEGACY MODE (no --pod): repo-wide diff scan of recently-changed files.
+    Kept for `/discover-bugs --since-cache|--commits N|--days N`.
 
 Usage:
-    python3 prepare-scan.py [--since-cache | --commits N | --days N]
-                            [--max-files N] [--files-per-chunk N] [--auto]
-
-Selection precedence (highest first):
-    --commits N      diff HEAD~N..HEAD
-    --days N         files touched by commits in the last N days
-    --since-cache    diff <lastScanSha>..HEAD   (default; falls back to --days 7)
+    python3 prepare-scan.py --pod ai-chat [--max-files N] [--files-per-chunk N] [--auto]
+    python3 prepare-scan.py --pod ai-chat --check      # gate: exit 0 if work exists
+    python3 prepare-scan.py --sync-doc                 # regenerate PODS.md from pods.json
+    python3 prepare-scan.py [--since-cache|--commits N|--days N]   # legacy
 """
 
 import argparse
-import hashlib
+import fnmatch
 import json
 import os
-import subprocess
+# subprocess is used only to invoke `git` with fixed, list-form argv (never
+# shell=True, never a shell string), so there is no shell-injection surface.
+import subprocess  # nosemgrep: gitlab.bandit.B404
 import sys
 import tempfile
 from datetime import datetime, timezone
@@ -45,6 +56,11 @@ def _resolve_target(rel):
 
 
 TARGET_REPO_PATH = _resolve_target(require_config(_config, "project.targetRepoPath"))
+PODS_PATH = os.path.join(_SCRIPT_DIR, "pods.json")
+# Per-pod cache files live here (one JSON per pod) so parallel pod cron jobs
+# never contend on a single cache file.
+POD_CACHE_DIR = os.path.join(_BOT_DIR, ".ignore", "discover-bugs")
+# Legacy repo-wide cache (non-pod mode).
 CACHE_PATH = os.path.join(_BOT_DIR, ".ignore", "discover-bugs-cache.json")
 
 # Source extensions worth scanning for logic/lifetime bugs.
@@ -53,11 +69,15 @@ SOURCE_EXTS = {".cc", ".cpp", ".cxx", ".mm", ".m", ".h", ".hpp", ".ts", ".tsx", 
 SKIP_SUBSTR = ("/test/", "/tests/", "/third_party/", "/node_modules/", "/gen/")
 SKIP_SUFFIX = ("_unittest.cc", "_browsertest.cc", "_unittest.mm", ".test.ts", ".test.tsx")
 
-DEFAULT_MAX_FILES = 40
+DEFAULT_MAX_FILES = 30
+# Cooldown between full-codebase sweeps of a pod (days). After a pod finishes
+# sweeping its whole tree it goes idle for this long, then re-scans from scratch.
+DEFAULT_RESCAN_DAYS = 14
 DEFAULT_FILES_PER_CHUNK = 5
 
-# Bug-class rubric handed to every subagent. Focused on the classes that
-# actually recur in Brave/Chromium C++ (the US-005 UAF was class #1).
+# Bug-class rubric handed to every subagent. Broad on purpose: the ask is
+# "code issues, bugs, security issues, any type" — memory safety, arithmetic,
+# concurrency, and logic errors.
 RUBRIC = """\
 Scan ONLY for high-confidence, concrete defects in the classes below. Do NOT
 report style, naming, or subjective design preferences.
@@ -65,18 +85,31 @@ report style, naming, or subjective design preferences.
 1. Lifetime / use-after-free: dangling `raw_ptr`/`raw_ref`, pointers outliving
    their owner, missing `RegisterWillDetach`/unsubscribe on teardown, capturing
    `this`/refs in callbacks that outlive the object, iterator invalidation.
-2. Threading / sequence: cross-sequence access without posting, missing
+2. Null / bad deref: unchecked deref of a pointer that can be null (`GetFoo()`
+   returning null, `WeakPtr` used after invalidation), unchecked `std::optional`.
+3. Bounds / memory safety: off-by-one, out-of-bounds index/iterator, unchecked
+   `.at()`/`[]`, buffer over-read/over-write, unbounded copy from untrusted size.
+4. Integer over/underflow & numeric: signed/unsigned overflow, truncating casts,
+   underflow on subtraction of unsigned amounts (common in wallet balance/fee
+   math), division by zero, precision loss.
+5. Stack overflow / unbounded recursion: recursion or allocation driven by
+   untrusted depth/size with no limit.
+6. Threading / sequence: cross-sequence access without posting, missing
    `SEQUENCE_CHECKER`, data races on shared state, blocking the UI thread.
-3. Null / bounds: unchecked deref of a pointer that can be null (`GetFoo()`
-   returning null, `WeakPtr` used after invalidation), off-by-one / OOB index.
-4. Mojo / IPC: trusting a renderer-supplied value without validation, missing
-   `mojo::ReportBadMessage`, lifetime of self-owned receivers.
-5. Uninitialized / resource: uninitialized member read, leaked handle/fd,
+7. Mojo / IPC & untrusted input: trusting a renderer- or server-supplied value
+   without validation, missing `mojo::ReportBadMessage`, parsing untrusted
+   network/JSON without bounds checks, self-owned receiver lifetime.
+8. Security & crypto: missing input validation, injection, weak/misused crypto,
+   key/secret lifetime (not zeroed), TOCTOU, unvalidated URLs/origins,
+   entitlement/permission bypass.
+9. Uninitialized / resource: uninitialized member read, leaked handle/fd,
    missing `Close()`/`Release()` on an error path.
+10. Logic errors: inverted conditions, wrong operator, incorrect state
+    transition, mishandled error/return value that leads to a concrete failure.
 
-For each finding you MUST be able to point to the exact line and explain the
-concrete failure (what input/state triggers it, what goes wrong). If you are
-not confident it is a real bug, DROP it — false positives are worse than misses.
+For each finding you MUST point to the exact line and explain the concrete
+failure (what input/state triggers it, what goes wrong). If you are not
+confident it is a real bug, DROP it — false positives are worse than misses.
 """
 
 
@@ -96,12 +129,66 @@ def git(*args):
         return ""
 
 
-def load_cache():
+# --- pod registry & selection -----------------------------------------------
+
+def load_pods():
+    with open(PODS_PATH) as f:
+        return json.load(f)
+
+
+def find_pod(pods_doc, pod_id):
+    for p in pods_doc.get("pods", []):
+        if p["id"] == pod_id:
+            return p
+    return None
+
+
+def pod_cache_path(pod_id):
+    return os.path.join(POD_CACHE_DIR, f"{pod_id}.json")
+
+
+def load_pod_cache(pod_id):
     try:
-        with open(CACHE_PATH) as f:
+        with open(pod_cache_path(pod_id)) as f:
             return json.load(f)
     except Exception:
-        return {"lastScanSha": None, "lastScanAt": None, "seen": {}}
+        return {"cycleComplete": False, "sweepCursor": "",
+                "cycleCompletedAt": None, "lastScanAt": None}
+
+
+def _pathspecs(globs):
+    """Directory pathspecs to bound `git ls-files` for a set of globs."""
+    specs = set()
+    for g in globs:
+        head = g.split("*", 1)[0]
+        if "/" in head:
+            specs.add(head.rsplit("/", 1)[0])
+        else:
+            specs.add(head)
+    return sorted(s for s in specs if s)
+
+
+def _matches(path, globs):
+    return any(fnmatch.fnmatch(path, g) for g in globs)
+
+
+def pod_all_files(pod):
+    """All tracked, scannable files in the pod's tree (sorted, deterministic)."""
+    specs = _pathspecs(pod["paths"])
+    raw = git("ls-files", "--", *specs) if specs else ""
+    include = pod["paths"]
+    exclude = pod.get("exclude", [])
+    files = []
+    for ln in raw.splitlines():
+        p = ln.strip()
+        if not p or not is_scannable(p):
+            continue
+        if not _matches(p, include):
+            continue
+        if exclude and _matches(p, exclude):
+            continue
+        files.append(p)
+    return sorted(set(files))
 
 
 def is_scannable(path):
@@ -115,13 +202,22 @@ def is_scannable(path):
     return True
 
 
+# --- legacy (non-pod) cache & selection -------------------------------------
+
+def load_cache():
+    try:
+        with open(CACHE_PATH) as f:
+            return json.load(f)
+    except Exception:
+        return {"lastScanSha": None, "lastScanAt": None, "seen": {}}
+
+
 def resolve_base(args, cache):
-    """Return (base_ref, description). base_ref is a git ref or None (window)."""
+    """Legacy base ref: return (base_ref, description). base_ref None = window."""
     if args.commits:
         return f"HEAD~{args.commits}", f"last {args.commits} commits"
     if args.days:
         return None, f"last {args.days} days"
-    # --since-cache (default)
     sha = cache.get("lastScanSha")
     if sha and git("rev-parse", "--verify", "--quiet", sha + "^{commit}"):
         return sha, f"since last scan ({sha[:12]})"
@@ -134,42 +230,49 @@ def changed_files(base_ref, days):
     if base_ref:
         raw = git("diff", "--name-only", f"{base_ref}..HEAD")
     else:
-        # files touched by commits within the window
         raw = git("log", f"--since={days} days ago", "--name-only",
                   "--pretty=format:", "HEAD")
     files = sorted({ln.strip() for ln in raw.splitlines() if ln.strip()})
     return [f for f in files if is_scannable(f)]
 
 
+# --- prompt construction -----------------------------------------------------
+
 def file_diff(base_ref, path):
-    """Diff for a changed file (bounded); full file if newly added / no base."""
+    """Diff for a changed file (bounded); full numbered file if no base."""
     if base_ref:
         d = git("diff", f"{base_ref}..HEAD", "--", path)
         if d:
             return d
-    # new file or window mode — show current content with line numbers
     full = os.path.join(TARGET_REPO_PATH, path)
     try:
         with open(full, encoding="utf-8", errors="replace") as f:
             lines = f.read().splitlines()
-        return "\n".join(f"{i+1:>5}\t{ln}" for i, ln in enumerate(lines[:1200]))
+        body = "\n".join(f"{i+1:>5}\t{ln}" for i, ln in enumerate(lines[:1200]))
+        if len(lines) > 1200:
+            body += f"\n... [truncated: {len(lines) - 1200} more lines not shown]"
+        return body
     except Exception:
         return ""
 
 
-def build_prompt(chunk_files, base_ref, results_file):
-    parts = [
-        "You are a C++/TypeScript bug-finding subagent scanning Brave (a Chromium "
-        "fork) source for concrete defects.\n",
-        RUBRIC,
-        "\n--- FILES TO SCAN (unified diffs; scan the changed/new code) ---\n",
-    ]
+def build_prompt(chunk_files, base_ref, results_file, pod=None):
+    header = ("You are a C++/TypeScript bug-finding subagent scanning Brave (a "
+              "Chromium fork) source for concrete defects.")
+    if pod:
+        header += (f"\n\nYou are scanning ONE product area: **{pod['label']}** "
+                   f"(`{pod['id']}`). Pay special attention to: {pod.get('focus','')}")
+    parts = [header + "\n\n", RUBRIC,
+             "\n--- FILES TO SCAN "
+             + ("(unified diffs; scan the changed/new code) ---\n"
+                if base_ref else "(full source with line numbers) ---\n")]
     for path in chunk_files:
         parts.append(f"\n### {path}\n```\n{file_diff(base_ref, path)}\n```\n")
     parts.append(f"""
 --- OUTPUT ---
-Read the actual source files under {TARGET_REPO_PATH} as needed to CONFIRM each
-finding before reporting it. Then write a JSON file to EXACTLY this path:
+Read the actual source files under {TARGET_REPO_PATH} as needed (follow includes
+/ callers / callees) to CONFIRM each finding before reporting it. Then write a
+JSON file to EXACTLY this path:
 
   {results_file}
 
@@ -179,11 +282,11 @@ Schema:
     {{
       "file": "<repo-relative path>",
       "line": <int>,
-      "bug_class": "lifetime|threading|null-bounds|mojo-ipc|uninitialized",
-      "severity": "low|medium|high",
+      "bug_class": "lifetime-uaf|null-deref|bounds|integer-over-underflow|stack-overflow|threading|mojo-ipc|security|uninitialized|resource-leak|logic-error",
+      "severity": "critical|high|medium|low",
       "confidence": "low|medium|high",
       "title": "<one line>",
-      "description": "<what input/state triggers it and what goes wrong>",
+      "description": "<what input/state triggers it and what concretely goes wrong>",
       "suggested_fix": "<concrete direction>"
     }}
   ]
@@ -195,21 +298,182 @@ Report ONLY confidence:high findings. If you find nothing solid, write
     return "".join(parts)
 
 
-def main():
-    ap = argparse.ArgumentParser()
-    g = ap.add_mutually_exclusive_group()
-    g.add_argument("--since-cache", action="store_true")
-    g.add_argument("--commits", type=int)
-    g.add_argument("--days", type=int)
-    ap.add_argument("--max-files", type=int, default=DEFAULT_MAX_FILES)
-    ap.add_argument("--files-per-chunk", type=int, default=DEFAULT_FILES_PER_CHUNK)
-    ap.add_argument("--auto", action="store_true")
-    args = ap.parse_args()
+def write_chunks(work_dir, files, files_per_chunk, base_ref, pod):
+    chunks = []
+    for i in range(0, len(files), files_per_chunk):
+        chunk_files = files[i: i + files_per_chunk]
+        cid = f"chunk_{i // files_per_chunk}"
+        prompt_file = os.path.join(work_dir, f"{cid}_prompt.txt")
+        results_file = os.path.join(work_dir, f"{cid}_results.json")
+        with open(prompt_file, "w") as f:
+            f.write(build_prompt(chunk_files, base_ref, results_file, pod))
+        chunks.append({"chunk_id": cid, "files": chunk_files,
+                       "prompt_file": prompt_file, "results_file": results_file})
+    return chunks
 
-    if not os.path.isdir(os.path.join(TARGET_REPO_PATH, ".git")):
-        log(f"Error: target repo not found at {TARGET_REPO_PATH}")
-        sys.exit(1)
 
+# --- pod-mode driver ---------------------------------------------------------
+
+def _days_since(iso):
+    """Whole days since an ISO timestamp; a large number if unset/unparseable."""
+    if not iso:
+        return 10 ** 6
+    try:
+        then = datetime.fromisoformat(iso)
+        if then.tzinfo is None:
+            then = then.replace(tzinfo=timezone.utc)
+        return (datetime.now(timezone.utc) - then).total_seconds() / 86400.0
+    except Exception:
+        return 10 ** 6
+
+
+def run_pod_mode(args):
+    pods_doc = load_pods()
+    pod = find_pod(pods_doc, args.pod)
+    if not pod:
+        log(f"Error: unknown pod '{args.pod}'. Known: "
+            + ", ".join(p["id"] for p in pods_doc["pods"]))
+        sys.exit(2)
+
+    cache = load_pod_cache(args.pod)
+    head_sha = git("rev-parse", "HEAD")
+
+    # Full-codebase model: ALWAYS scan the pod's whole tree on master (full
+    # source, never diffs). The tree is swept in bounded slices, rotating across
+    # runs via a cursor. When a full sweep completes, the pod goes idle for a
+    # cooldown (rescan interval), then sweeps the whole tree again.
+    rescan_days = pod.get("rescan_interval_days", args.rescan_days)
+    all_files = pod_all_files(pod)
+    total_pod = len(all_files)
+    cursor = cache.get("sweepCursor", "") or ""
+    cycle_complete = bool(cache.get("cycleComplete"))
+
+    scan_mode = "full-sweep"
+    base_ref = None  # full source content, no diffs
+
+    if cycle_complete:
+        # Waiting out the cooldown before starting the next full sweep.
+        idle_days = _days_since(cache.get("cycleCompletedAt"))
+        if idle_days >= rescan_days:
+            cursor = ""  # start a fresh full sweep of the whole tree
+        else:
+            remaining = []
+            batch = []
+            is_last_batch = False
+            done_before = total_pod
+            wait = max(0, rescan_days - idle_days)
+            base_desc = (f"idle — full sweep complete {idle_days:.1f}d ago; "
+                         f"next re-scan in ~{wait:.1f}d (rescan every {rescan_days}d)")
+            _emit_pod(args, pod, cache, head_sha, scan_mode, base_ref, batch,
+                      is_last_batch, total_pod, base_desc)
+            return
+
+    remaining = [f for f in all_files if f > cursor]
+    batch = remaining[: args.max_files]
+    is_last_batch = 0 < len(remaining) <= args.max_files
+    done_before = total_pod - len(remaining)
+    base_desc = (f"full-codebase sweep {done_before + len(batch)}/{total_pod} "
+                 f"file(s) of {pod['id']} tree (master)")
+
+    _emit_pod(args, pod, cache, head_sha, scan_mode, base_ref, batch,
+              is_last_batch, total_pod, base_desc)
+
+
+def _emit_pod(args, pod, cache, head_sha, scan_mode, base_ref, batch,
+              is_last_batch, total_pod, base_desc):
+    # --check: gate only. Print yes/no and exit; never build a work dir.
+    if args.check:
+        has_work = len(batch) > 0
+        print("yes" if has_work else "no")
+        log(f"discover-bugs[{pod['id']}]: {scan_mode} — {len(batch)} file(s) to scan.")
+        sys.exit(0 if has_work else 1)
+
+    work_dir = tempfile.mkdtemp(prefix=f"discover-bugs-{pod['id']}-")
+    chunks = write_chunks(work_dir, batch, args.files_per_chunk, base_ref, pod)
+
+    batch_last_path = batch[-1] if batch else cache.get("sweepCursor", "")
+    progress = [
+        f"discover-bugs[{pod['id']}]: {pod['label']} — mode={scan_mode}",
+        f"discover-bugs[{pod['id']}]: {base_desc}",
+        f"discover-bugs[{pod['id']}]: {len(batch)} file(s) -> {len(chunks)} chunk(s)",
+    ]
+    if is_last_batch:
+        progress.append(f"discover-bugs[{pod['id']}]: this run COMPLETES the full "
+                        f"sweep; pod idles until the next re-scan cycle.")
+    for line in progress:
+        log(line)
+
+    manifest = {
+        "work_dir": work_dir,
+        "mode": "pod",
+        "pod_id": pod["id"],
+        "pod_label": pod["label"],
+        "scan_mode": scan_mode,
+        "auto_mode": args.auto,
+        "issue_repo": ISSUE_REPO,
+        "target_repo_path": TARGET_REPO_PATH,
+        "base_ref": base_ref,
+        "base_desc": base_desc,
+        "head_sha": head_sha,
+        "pod_cache_path": pod_cache_path(pod["id"]),
+        "cache_path": pod_cache_path(pod["id"]),
+        "sweep_total": total_pod,
+        "batch_size": len(batch),
+        "batch_last_path": batch_last_path,
+        "cycle_complete_after": bool(is_last_batch),
+        "capped": False,
+        "chunks": chunks,
+        "progress_lines": progress,
+    }
+    manifest_path = os.path.join(work_dir, "manifest.json")
+    with open(manifest_path, "w") as f:
+        json.dump(manifest, f, indent=2)
+
+    print(json.dumps({"work_dir": work_dir, "manifest": manifest_path}))
+
+
+# --- doc generation ----------------------------------------------------------
+
+def sync_doc():
+    pods_doc = load_pods()
+    lines = [
+        "# Bug-scan pods",
+        "",
+        "> **Generated from `pods.json` — do not edit by hand.**",
+        "> Edit `pods.json` and run `python3 prepare-scan.py --sync-doc` to regenerate.",
+        "",
+        f"Target repo: **brave-core** · branch: **{pods_doc.get('target_branch','master')}**.",
+        "",
+        "Each pod below is one scan task: its own cron job and its own subagent. "
+        "A pod sweeps its **entire tree** on master as full source (never diffs), "
+        "bounded per run and rotating across runs until the whole tree is covered; "
+        "then it idles for a cooldown and re-scans the whole codebase again. "
+        "Findings are prioritized (P0/P1/P2) and filed as `ai-generated` issues "
+        "for human confirmation.",
+        "",
+        f"**{len(pods_doc['pods'])} scan tasks:**",
+        "",
+        "| # | Pod id | Area | Paths |",
+        "| - | ------ | ---- | ----- |",
+    ]
+    for i, p in enumerate(pods_doc["pods"], 1):
+        paths = "<br>".join(f"`{g}`" for g in p["paths"])
+        lines.append(f"| {i} | `{p['id']}` | {p['label']} | {paths} |")
+    lines += ["", "## Focus per pod", ""]
+    for p in pods_doc["pods"]:
+        lines.append(f"- **{p['label']}** (`{p['id']}`): {p.get('focus','')}")
+        if p.get("exclude"):
+            lines.append(f"  - excludes: " + ", ".join(f"`{g}`" for g in p["exclude"]))
+    lines.append("")
+    out = os.path.join(_SCRIPT_DIR, "PODS.md")
+    with open(out, "w") as f:
+        f.write("\n".join(lines))
+    log(f"Wrote {out} ({len(pods_doc['pods'])} pods).")
+
+
+# --- legacy driver -----------------------------------------------------------
+
+def run_legacy(args):
     cache = load_cache()
     base_ref, base_desc = resolve_base(args, cache)
     head_sha = git("rev-parse", "HEAD")
@@ -222,16 +486,7 @@ def main():
         capped = True
 
     work_dir = tempfile.mkdtemp(prefix="discover-bugs-")
-    chunks = []
-    for i in range(0, len(files), args.files_per_chunk):
-        chunk_files = files[i : i + args.files_per_chunk]
-        cid = f"chunk_{i // args.files_per_chunk}"
-        prompt_file = os.path.join(work_dir, f"{cid}_prompt.txt")
-        results_file = os.path.join(work_dir, f"{cid}_results.json")
-        with open(prompt_file, "w") as f:
-            f.write(build_prompt(chunk_files, base_ref, results_file))
-        chunks.append({"chunk_id": cid, "files": chunk_files,
-                       "prompt_file": prompt_file, "results_file": results_file})
+    chunks = write_chunks(work_dir, files, args.files_per_chunk, base_ref, None)
 
     progress = [f"discover-bugs: base = {base_desc}",
                 f"discover-bugs: {total_found} scannable file(s) changed"
@@ -245,6 +500,7 @@ def main():
 
     manifest = {
         "work_dir": work_dir,
+        "mode": "legacy",
         "auto_mode": args.auto,
         "issue_repo": ISSUE_REPO,
         "target_repo_path": TARGET_REPO_PATH,
@@ -263,6 +519,40 @@ def main():
         json.dump(manifest, f, indent=2)
 
     print(json.dumps({"work_dir": work_dir, "manifest": manifest_path}))
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--pod", help="Scan a single pod from pods.json.")
+    ap.add_argument("--check", action="store_true",
+                    help="Gate only: print yes/no and exit 0/1, no work dir.")
+    ap.add_argument("--sync-doc", action="store_true",
+                    help="Regenerate PODS.md from pods.json and exit.")
+    g = ap.add_mutually_exclusive_group()
+    g.add_argument("--since-cache", action="store_true")
+    g.add_argument("--commits", type=int)
+    g.add_argument("--days", type=int)
+    ap.add_argument("--max-files", type=int, default=DEFAULT_MAX_FILES)
+    ap.add_argument("--files-per-chunk", type=int, default=DEFAULT_FILES_PER_CHUNK)
+    ap.add_argument("--rescan-days", type=int, default=DEFAULT_RESCAN_DAYS,
+                    help="Cooldown (days) after a full sweep before re-scanning "
+                         "the whole tree again. Per-pod override: "
+                         "'rescan_interval_days' in pods.json.")
+    ap.add_argument("--auto", action="store_true")
+    args = ap.parse_args()
+
+    if args.sync_doc:
+        sync_doc()
+        return
+
+    if not os.path.isdir(os.path.join(TARGET_REPO_PATH, ".git")):
+        log(f"Error: target repo not found at {TARGET_REPO_PATH}")
+        sys.exit(1)
+
+    if args.pod:
+        run_pod_mode(args)
+    else:
+        run_legacy(args)
 
 
 if __name__ == "__main__":

--- a/README.md
+++ b/README.md
@@ -200,6 +200,7 @@ Bot-only skills are available as slash commands in Claude Code. 8 bot-specific s
 | Skill | Description |
 |-------|-------------|
 | `/review-prs` | Batch review PRs for best practices violations. Supports auto mode for cron. Deduplicates against existing bot comments. Tracks prior comment context |
+| `/discover-bugs` | Static scan of recently-changed target-repo code for likely bugs (lifetime/UAF, threading, null-deref, mojo/IPC, uninitialized). Verify-first; report-only by default, files `ai-generated` issues with `file-issues`. Deduplicates across runs |
 | `/learnable-pattern-search` | Analyze PR review comments to discover learnable patterns. Supports self-review mode to identify overly strict rules |
 | `/update-best-practices` | Fetch and merge upstream Chromium documentation guidelines |
 
@@ -511,6 +512,7 @@ brave-dev-bot/                 # (or your clone name)
 │       ├── prd-clean/         # Archive merged/invalid stories
 │       ├── add-backlog-to-prd/  # Fetch issues from GitHub
 │       ├── review-prs/        # Batch PR review with caching
+│       ├── discover-bugs/     # Static bug scan of changed code
 │       ├── check-signal/      # Check incoming Signal messages
 │       ├── update-best-practices/ # Merge upstream Chromium guidelines
 │       └── learnable-pattern-search/  # Analyze PR reviews for patterns

--- a/README.md
+++ b/README.md
@@ -200,7 +200,7 @@ Bot-only skills are available as slash commands in Claude Code. 8 bot-specific s
 | Skill | Description |
 |-------|-------------|
 | `/review-prs` | Batch review PRs for best practices violations. Supports auto mode for cron. Deduplicates against existing bot comments. Tracks prior comment context |
-| `/discover-bugs` | Static scan of recently-changed target-repo code for likely bugs (lifetime/UAF, threading, null-deref, mojo/IPC, uninitialized). Verify-first; report-only by default, files `ai-generated` issues with `file-issues`. Deduplicates across runs |
+| `/discover-bugs` | Per-product/pod static scan of brave-core (master) for bugs (lifetime/UAF, threading, null/bounds, integer over-underflow, stack overflow, mojo/IPC, security/crypto, logic errors). `--pod <id>` scans one pod (baseline-sweeps its whole tree, then changed-only); pods are defined in `pods.json` (see `PODS.md`), each with its own staggered cron job/subagent. Verify-first; findings prioritized P0/P1/P2; files `ai-generated` issues with `file-issues`. Deduplicates across runs |
 | `/learnable-pattern-search` | Analyze PR review comments to discover learnable patterns. Supports self-review mode to identify overly strict rules |
 | `/update-best-practices` | Fetch and merge upstream Chromium documentation guidelines |
 
@@ -512,7 +512,7 @@ brave-dev-bot/                 # (or your clone name)
 │       ├── prd-clean/         # Archive merged/invalid stories
 │       ├── add-backlog-to-prd/  # Fetch issues from GitHub
 │       ├── review-prs/        # Batch PR review with caching
-│       ├── discover-bugs/     # Static bug scan of changed code
+│       ├── discover-bugs/     # Per-pod static bug scan (pods.json / PODS.md)
 │       ├── check-signal/      # Check incoming Signal messages
 │       ├── update-best-practices/ # Merge upstream Chromium guidelines
 │       └── learnable-pattern-search/  # Analyze PR reviews for patterns

--- a/scripts/check-pod-candidates.sh
+++ b/scripts/check-pod-candidates.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+# Gate script for a per-pod discover-bugs cron job.
+# Exits 0 if the pod has work to scan (baseline not finished, or changed files
+# since the last scan). Exits 1 otherwise (no target repo, or nothing to do).
+#
+# Usage in cron:
+#   ./scripts/check-pod-candidates.sh <pod-id> && ... && $CLAUDE_BIN -p '/discover-bugs --pod <pod-id> auto file-issues'
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+BOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+source "$SCRIPT_DIR/lib/load-config.sh"
+
+POD="$1"
+if [ -z "$POD" ]; then
+  echo "usage: check-pod-candidates.sh <pod-id>" >&2
+  exit 1
+fi
+
+TARGET="$BOT_TARGET_REPO_PATH"
+if [[ "$TARGET" != /* ]]; then
+  TARGET="$(cd "$BOT_DIR/.." && pwd)/$TARGET"
+fi
+
+if [ ! -d "$TARGET/.git" ]; then
+  echo "No target repo at $TARGET — skipping $POD scan."
+  exit 1
+fi
+
+# prepare-scan.py --check prints yes/no and exits 0 (work) / 1 (nothing).
+python3 "$BOT_DIR/.claude/skills/discover-bugs/prepare-scan.py" --pod "$POD" --check
+exit $?

--- a/scripts/check-scan-candidates.sh
+++ b/scripts/check-scan-candidates.sh
@@ -1,0 +1,46 @@
+#!/bin/bash
+# Gate script for the discover-bugs cron job.
+# Exits 0 if the target repo has scannable source changes since the last scan.
+# Exits 1 otherwise (no target repo, or nothing new to scan).
+#
+# Usage in cron: ./scripts/check-scan-candidates.sh && ... && $CLAUDE_BIN -p '/discover-bugs --since-cache auto'
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+BOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+source "$SCRIPT_DIR/lib/load-config.sh"
+
+TARGET="$BOT_TARGET_REPO_PATH"
+if [[ "$TARGET" != /* ]]; then
+  TARGET="$(cd "$BOT_DIR/.." && pwd)/$TARGET"
+fi
+
+if [ ! -d "$TARGET/.git" ]; then
+  echo "No target repo at $TARGET — skipping scan."
+  exit 1
+fi
+
+CACHE="$BOT_DIR/.ignore/discover-bugs-cache.json"
+LAST_SHA=""
+[ -f "$CACHE" ] && LAST_SHA=$(jq -r '.lastScanSha // empty' "$CACHE" 2>/dev/null)
+
+# Determine changed source files since last scan (or last 7 days on first run).
+if [ -n "$LAST_SHA" ] && git -C "$TARGET" rev-parse --verify --quiet "${LAST_SHA}^{commit}" >/dev/null; then
+  CHANGED=$(git -C "$TARGET" diff --name-only "${LAST_SHA}..HEAD")
+else
+  CHANGED=$(git -C "$TARGET" log --since="7 days ago" --name-only --pretty=format: HEAD)
+fi
+
+# Count scannable source files (exclude tests/third_party/generated).
+COUNT=$(echo "$CHANGED" \
+  | grep -Ei '\.(cc|cpp|cxx|mm|m|h|hpp|ts|tsx|js)$' \
+  | grep -Ev '/(test|tests|third_party|node_modules|gen)/' \
+  | grep -Ev '(_unittest|_browsertest)\.' \
+  | sort -u | grep -c . || true)
+
+if [ "${COUNT:-0}" -eq 0 ]; then
+  echo "No scannable source changes since last scan — skipping."
+  exit 1
+fi
+
+echo "$COUNT scannable changed file(s) — proceeding with scan."
+exit 0

--- a/scripts/sync-schedules.sh
+++ b/scripts/sync-schedules.sh
@@ -64,6 +64,12 @@ PATH=$CLAUDE_BIN_DIR:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bi
 # Gate check runs before git sync to avoid wasted fetches
 0 6 * * * cd $PROJECT_ROOT && source .envrc && ./scripts/check-bot-prs.sh && git fetch origin && git checkout $BOT_REPO_BRANCH && git reset --hard origin/$BOT_REPO_BRANCH && ./scripts/sync-brave-core.sh && ./scripts/with-lock.sh learnable-pattern-search -- $CLAUDE_BIN -p '/learnable-pattern-search 2d' --allowedTools '$CLAUDE_TOOLS' >> $LOG_DIR/learnable-pattern-search-cron.log 2>&1
 
+# Discover bugs (static scan) — skip if no scannable source changes since last scan
+# Gate check runs before git sync to avoid wasted fetches.
+# REPORT-ONLY: writes logs/discover-bugs-*.md, files NO issues. Add 'file-issues'
+# to the skill args below only once the false-positive rate is acceptable.
+0 5 * * * cd $PROJECT_ROOT && source .envrc && ./scripts/check-scan-candidates.sh && git fetch origin && git checkout $BOT_REPO_BRANCH && git reset --hard origin/$BOT_REPO_BRANCH && ./scripts/sync-brave-core.sh && ./scripts/with-lock.sh discover-bugs -- $CLAUDE_BIN -p '/discover-bugs --since-cache auto' --allowedTools '$CLAUDE_TOOLS' >> $LOG_DIR/discover-bugs-cron.log 2>&1
+
 # Check Signal messages (every 5 min, offset to avoid git lock contention with other jobs)
 # Gate check runs before git sync to avoid wasted fetches (288 runs/day, most exit early)
 1,6,11,16,21,26,31,36,41,46,51,56 * * * * cd $PROJECT_ROOT && source .envrc && ./scripts/check-signal-messages.sh && git fetch origin && git checkout $BOT_REPO_BRANCH && git reset --hard origin/$BOT_REPO_BRANCH && ./scripts/with-lock.sh check-signal -- $CLAUDE_BIN -p '/check-signal' --allowedTools '$CLAUDE_TOOLS' >> $LOG_DIR/check-signal-cron.log 2>&1
@@ -107,6 +113,7 @@ echo "    14:10 - run.sh (3 iterations)"
 echo "    11:45 - /add-backlog-to-prd"
 echo "    12:00 - /review-prs"
 echo "  Daily:"
+echo "    05:00 - /discover-bugs (report-only; only if source changed)"
 echo "    06:00 - /learnable-pattern-search"
 echo "    Every 5 min at :01,:06,...,:56 - /check-signal (only if messages pending)"
 echo "    1st of month, 04:15 - /update-best-practices"

--- a/scripts/sync-schedules.sh
+++ b/scripts/sync-schedules.sh
@@ -30,6 +30,22 @@ BOT_REPO_BRANCH="${BOT_REPO_BRANCH:-master}"
 
 CRON_MARKER="brave-dev-bot ($BOT_PROJECT_NAME)"
 
+# Per-pod bug-discovery jobs — one cron per pod, so a different subagent works
+# on exactly one product/pod task. Pod list is the single source of truth in
+# pods.json: adding a pod there and re-running this script installs its cron.
+# Times are staggered from 05:00 in 20-min steps to avoid git/lock contention.
+PODS_JSON="$PROJECT_ROOT/.claude/skills/discover-bugs/pods.json"
+DISCOVER_POD_JOBS=""
+if [ -f "$PODS_JSON" ]; then
+  POD_IDS=$(python3 -c "import json;print(' '.join(p['id'] for p in json.load(open('$PODS_JSON'))['pods']))")
+  POD_I=0
+  for POD_ID in $POD_IDS; do
+    TOT=$((5 * 60 + POD_I * 20)); PH=$((TOT / 60)); PM=$((TOT % 60))
+    DISCOVER_POD_JOBS+="$PM $PH * * * cd $PROJECT_ROOT && source .envrc && ./scripts/check-pod-candidates.sh $POD_ID && git fetch origin && git checkout $BOT_REPO_BRANCH && git reset --hard origin/$BOT_REPO_BRANCH && ./scripts/sync-brave-core.sh && ./scripts/with-lock.sh discover-bugs-$POD_ID -- $CLAUDE_BIN -p '/discover-bugs --pod $POD_ID auto file-issues' --allowedTools '$CLAUDE_TOOLS' >> $LOG_DIR/discover-bugs-$POD_ID-cron.log 2>&1"$'\n'
+    POD_I=$((POD_I + 1))
+  done
+fi
+
 # Build the crontab content
 # Note: add-backlog-to-prd runs 15 min before each run.sh invocation
 # Weekday (1-5 = Mon-Fri) schedules run more frequently than weekend (0,6 = Sat-Sun)
@@ -64,11 +80,11 @@ PATH=$CLAUDE_BIN_DIR:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bi
 # Gate check runs before git sync to avoid wasted fetches
 0 6 * * * cd $PROJECT_ROOT && source .envrc && ./scripts/check-bot-prs.sh && git fetch origin && git checkout $BOT_REPO_BRANCH && git reset --hard origin/$BOT_REPO_BRANCH && ./scripts/sync-brave-core.sh && ./scripts/with-lock.sh learnable-pattern-search -- $CLAUDE_BIN -p '/learnable-pattern-search 2d' --allowedTools '$CLAUDE_TOOLS' >> $LOG_DIR/learnable-pattern-search-cron.log 2>&1
 
-# Discover bugs (static scan) — skip if no scannable source changes since last scan
-# Gate check runs before git sync to avoid wasted fetches.
-# REPORT-ONLY: writes logs/discover-bugs-*.md, files NO issues. Add 'file-issues'
-# to the skill args below only once the false-positive rate is acceptable.
-0 5 * * * cd $PROJECT_ROOT && source .envrc && ./scripts/check-scan-candidates.sh && git fetch origin && git checkout $BOT_REPO_BRANCH && git reset --hard origin/$BOT_REPO_BRANCH && ./scripts/sync-brave-core.sh && ./scripts/with-lock.sh discover-bugs -- $CLAUDE_BIN -p '/discover-bugs --since-cache auto' --allowedTools '$CLAUDE_TOOLS' >> $LOG_DIR/discover-bugs-cron.log 2>&1
+# Discover bugs (per-pod static scan) — ONE cron per pod (brave-core, master).
+# Each pod first baseline-sweeps its whole tree (bounded, rotating across runs),
+# then switches to changed-only. Its gate skips when the pod has no work.
+# Files prioritized (P0/P1/P2) ai-generated issues for human confirmation.
+$DISCOVER_POD_JOBS
 
 # Check Signal messages (every 5 min, offset to avoid git lock contention with other jobs)
 # Gate check runs before git sync to avoid wasted fetches (288 runs/day, most exit early)
@@ -113,7 +129,7 @@ echo "    14:10 - run.sh (3 iterations)"
 echo "    11:45 - /add-backlog-to-prd"
 echo "    12:00 - /review-prs"
 echo "  Daily:"
-echo "    05:00 - /discover-bugs (report-only; only if source changed)"
+echo "    05:00-12:20 - /discover-bugs per pod (one cron each; only if pod has work)"
 echo "    06:00 - /learnable-pattern-search"
 echo "    Every 5 min at :01,:06,...,:56 - /check-signal (only if messages pending)"
 echo "    1st of month, 04:15 - /update-best-practices"


### PR DESCRIPTION
## What

Adds a `discover-bugs` skill: a verify-first static bug scanner for brave-core (master). Scans product code per pod, has subagents confirm each finding against real source, prioritizes P0/P1/P2, and files `ai-generated` GitHub issues for a human to confirm. Never auto-fixes.

## How it works

Three-stage pipeline; the main LLM session never sees file contents:

1. `prepare-scan.py` (0 tokens) — select files, write one subagent prompt per chunk + a manifest.
2. subagents (Haiku) — one per chunk, read the real source to confirm findings, write a results JSON.
3. `collect-findings.py` (0 tokens) — confidence gate, dedup, prioritize, then local report or file issues; advance the per-pod cache.

Each pod = one product area (22 in `pods.json`: wallet split by chain/keyring/core, ai-chat, shields, vpn, sync, tor, …), distinguished by path globs. A pod scans its **entire tree on master as full source (never diffs)**, in bounded slices via a cursor until the whole tree is covered, then idles for a cooldown (`rescan_interval_days`, default 14) and re-sweeps. One cron per pod, staggered daily; the gate skips a pod when it has no work.

## How to run

**Skill (manual):**
```
/discover-bugs --pod <id>              # report-only -> logs/discover-bugs-<pod>-<stamp>.md
/discover-bugs --pod <id> file-issues  # also files ai-generated GitHub issues
```

**Cron (scheduled):**
```
bash scripts/sync-schedules.sh         # installs one job per pod (auto file-issues)
```

**Scripts (testing / full control):**
```
python3 .claude/skills/discover-bugs/prepare-scan.py --pod <id> [--check] [--max-files N] [--files-per-chunk N] [--rescan-days N]
python3 .claude/skills/discover-bugs/collect-findings.py --work-dir "$WORK_DIR" [--file-issues]
```

Report-only by default; add `file-issues` / `--file-issues` to post to GitHub. Full flag reference: `.claude/skills/discover-bugs/USAGE.md`.

Valid pod ids: `ai-chat`, `wallet-ethereum`, `wallet-solana`, `wallet-bitcoin`, `wallet-zcash`, `wallet-other-chains`, `wallet-keyring`, `wallet-core`, `shields`, `adblock`, `fingerprinting`, `sync`, `vpn`, `talk`, `talk-premium`, `news`, `sidebar`, `speedreader`, `tor`, `wayback-machine`, `web-discovery`, `email-aliases`.

## Notes

- brave-core, master only.
- Scan subagents run on Haiku to keep cost low 
- Dedup (per-pod seen-list + open `ai-generated` issue titles) makes re-runs and re-scan cycles safe.
- Adding a pod: edit `pods.json`, run `prepare-scan.py --sync-doc`, re-run `sync-schedules.sh`. Verify with `prepare-scan.py --pod <id> --check` (must print `yes`).